### PR TITLE
Fix bug with illegal characters (0) in pdb_seqres database

### DIFF
--- a/modules/local/run_af2.nf
+++ b/modules/local/run_af2.nf
@@ -40,7 +40,7 @@ process RUN_AF2 {
         model_preset = model_preset + " --pdb70_database_path=./pdb70/pdb70_from_mmcif_200916/pdb70 "
     }
     """
-    if [ -d pdb_seqres/pdb_seqres.txt ]; then sed -i '/^\w*0/d' pdb_seqres/pdb_seqres.txt; fi
+    if [ -d pdb_seqres/pdb_seqres.txt ]; then sed -i "/^\\w*0/d" pdb_seqres/pdb_seqres.txt; fi
     if [ -d params/alphafold_params_* ]; then ln -r -s params/alphafold_params_*/* params/; fi
     python3 /app/alphafold/run_alphafold.py \
         --fasta_paths=${fasta} \

--- a/modules/local/run_af2.nf
+++ b/modules/local/run_af2.nf
@@ -40,6 +40,7 @@ process RUN_AF2 {
         model_preset = model_preset + " --pdb70_database_path=./pdb70/pdb70_from_mmcif_200916/pdb70 "
     }
     """
+    if [ -d pdb_seqres/pdb_seqres.txt ]; then sed -i '/^\w*0/d' pdb_seqres/pdb_seqres.txt; fi
     if [ -d params/alphafold_params_* ]; then ln -r -s params/alphafold_params_*/* params/; fi
     python3 /app/alphafold/run_alphafold.py \
         --fasta_paths=${fasta} \

--- a/modules/local/run_af2_msa.nf
+++ b/modules/local/run_af2_msa.nf
@@ -39,6 +39,7 @@ process RUN_AF2_MSA {
         model_preset = model_preset + " --pdb70_database_path=./pdb70/pdb70_from_mmcif_200916/pdb70 "
     }
     """
+    if [ -d pdb_seqres/pdb_seqres.txt ]; then sed -i '/^\w*0/d' pdb_seqres/pdb_seqres.txt; fi
     python3 /app/alphafold/run_msa.py \
         --fasta_paths=${fasta} \
         --model_preset=${model_preset} \

--- a/modules/local/run_af2_msa.nf
+++ b/modules/local/run_af2_msa.nf
@@ -39,7 +39,7 @@ process RUN_AF2_MSA {
         model_preset = model_preset + " --pdb70_database_path=./pdb70/pdb70_from_mmcif_200916/pdb70 "
     }
     """
-    if [ -d pdb_seqres/pdb_seqres.txt ]; then sed -i '/^\w*0/d' pdb_seqres/pdb_seqres.txt; fi
+    if [ -d pdb_seqres/pdb_seqres.txt ]; then sed -i "/^\\w*0/d" pdb_seqres/pdb_seqres.txt; fi
     python3 /app/alphafold/run_msa.py \
         --fasta_paths=${fasta} \
         --model_preset=${model_preset} \


### PR DESCRIPTION
Since the problem won't be fixed on the AlphaFold side, we decided to include the filtering of the problematic rows in the process. The reason is that even if this is fixed in new versions of the DB, it will be possible to still use the previous versions of the DBs that included the problem described in #39 

<!--
# nf-core/proteinfold pull request

Many thanks for contributing to nf-core/proteinfold!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).

Fixes #39 