### PR TITLE
creates the versions.yml in the process folder

### DIFF
--- a/modules/local/mmseqs_createindex.nf
+++ b/modules/local/mmseqs_createindex.nf
@@ -24,7 +24,7 @@ process MMSEQS_CREATEINDEX {
         tmp1 \\
         --remove-tmp-files 1 \\
         $args
-
+    cd ..
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mmseqs: \$(mmseqs | grep 'Version' | sed 's/MMseqs2 Version: //')

--- a/modules/local/mmseqs_tsv2exprofiledb.nf
+++ b/modules/local/mmseqs_tsv2exprofiledb.nf
@@ -21,7 +21,7 @@ process MMSEQS_TSV2EXPROFILEDB {
     mmseqs tsv2exprofiledb \\
         "${db}" \\
         "${db}_db"
-
+    cd ..
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mmseqs: \$(mmseqs | grep 'Version' | sed 's/MMseqs2 Version: //')


### PR DESCRIPTION
## PR checklist

- [x ] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/proteinfold _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).

Close https://github.com/nf-core/proteinfold/issues/44 `versions.yml` is saved in the process working directory and not inside the `db` dir.
Another options would be to change the reference in the `output` field for versions and set the path relative to the actual db.