### PR TITLE
remove wrong suffix from colabfold local dirs

### DIFF
--- a/subworkflows/local/prepare_colabfold_dbs.nf
+++ b/subworkflows/local/prepare_colabfold_dbs.nf
@@ -34,8 +34,8 @@ workflow PREPARE_COLABFOLD_DBS {
     if (params.colabfold_db) {
         ch_params       = file( "${params.colabfold_db}/params/alphafold_params_*", type: 'any' )
         if (params.mode == 'colabfold_local') {
-            ch_colabfold_db = file( "${params.colabfold_db}/colabfold_envdb_202108_db", type: 'any' )
-            ch_uniref30     = file( "${params.colabfold_db}/uniref30_2103_db", type: 'any' )
+            ch_colabfold_db = file( "${params.colabfold_db}/colabfold_envdb_202108", type: 'any' )
+            ch_uniref30     = file( "${params.colabfold_db}/uniref30_2103", type: 'any' )
         }
     }
     else {


### PR DESCRIPTION
## PR checklist

- [X] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/proteinfold _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).

Closes #50 removing the `_db` suffix from the local directories in the `colabfold_local` preparation process.