### PR TITLE
Update AF2_split to 2.2.4

### DIFF
--- a/containers/Dockerfile_AF2_MSA
+++ b/containers/Dockerfile_AF2_MSA
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 # Clone AF2 git checkout d3327d968c6cfa31da53324c173ff635ed1ec0b6 && \
 RUN git clone https://github.com/luisas/alphafold_split.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout 5cb2f8c480aa8314c02a93c6fbfc3f48f0ce8af0 && \
+    git checkout 3a8535cee46a35ed0462c2112e96a832eeb3f4ae && \
     cd -
 
 # Compile HHsuite from source

--- a/containers/Dockerfile_AF2_MSA
+++ b/containers/Dockerfile_AF2_MSA
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 # Clone AF2 git checkout d3327d968c6cfa31da53324c173ff635ed1ec0b6 && \
 RUN git clone https://github.com/luisas/alphafold_split.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout 3a8535cee46a35ed0462c2112e96a832eeb3f4ae && \
+    git checkout 5cb2f8c480aa8314c02a93c6fbfc3f48f0ce8af0 && \
     cd -
 
 # Compile HHsuite from source

--- a/containers/Dockerfile_AF2_MSA
+++ b/containers/Dockerfile_AF2_MSA
@@ -1,24 +1,19 @@
-FROM nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu18.04
+FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
 LABEL authors="Luisa Santus, Athanasios Baltzis" \
     title="nf-friendly AF2 MSA docker image" \
-    Version="v0.1" \
+    Version="v2.2.4" \
     description="Docker image containing all software requirements to run AF2_MSA using the nf-core/proteinfold pipeline"
 
 
 # Use bash to support string substitution.
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Add env variables
 ENV LD_LIBRARY_PATH="/conda/lib:/usr/local/cuda-11.1/lib64:$LD_LIBRARY_PATH"
 ENV PATH="/conda/bin:$PATH"
 
-RUN rm /etc/apt/sources.list.d/cuda.list && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list && \
-    apt-key del 7fa2af80 && \
-    apt-get update && apt-get install -y --no-install-recommends wget && \
-    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb && \
-    dpkg -i cuda-keyring_1.0-1_all.deb
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         build-essential \
         cmake \
         cuda-command-line-tools-11-1 \
@@ -27,13 +22,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         kalign \
         tzdata \
         wget \
-        vim \
-        && rm -rf /var/lib/apt/lists/*
+        && rm -rf /var/lib/apt/lists/* \
+        && apt-get autoremove -y \
+        && apt-get clean
 
 # Clone AF2 git checkout d3327d968c6cfa31da53324c173ff635ed1ec0b6 && \
 RUN git clone https://github.com/luisas/alphafold_split.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout 095768b24e9ee76a3f0f85c706f2f91cbfca659f && \
+    git checkout 3a8535cee46a35ed0462c2112e96a832eeb3f4ae && \
     cd -
 
 # Compile HHsuite from source

--- a/containers/Dockerfile_AF2_split
+++ b/containers/Dockerfile_AF2_split
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 # Clone AF2
 RUN git clone https://github.com/luisas/alphafold_split.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout 5cb2f8c480aa8314c02a93c6fbfc3f48f0ce8af0 && \
+    git checkout 3a8535cee46a35ed0462c2112e96a832eeb3f4ae && \
     cd -
 
 # Compile HHsuite from source

--- a/containers/Dockerfile_AF2_split
+++ b/containers/Dockerfile_AF2_split
@@ -1,19 +1,19 @@
-FROM nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu18.04
-LABEL authors="Athanasios Baltzis, Luisa Santus" \
-    title="nf-friendly AF2_PRED docker image" \
-    Version="v1.0" \
-    description="Docker image containing all software requirements to run AF2_PRED step using the nf-core/proteinfold pipeline"
+FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
+LABEL authors="Athanasios Baltzis" \
+    title="nf-friendly AF2 docker image" \
+    Version="v0.9" \
+    description="Docker image containing all software requirements to run AF2 using the nf-core/proteinfold pipeline"
 
 
 # Use bash to support string substitution.
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Add env variables
-ARG CUDA=11.1.1
 ENV LD_LIBRARY_PATH="/conda/lib:/usr/local/cuda-11.1/lib64:$LD_LIBRARY_PATH"
 ENV PATH="/conda/bin:$PATH"
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         build-essential \
         cmake \
         cuda-command-line-tools-11-1 \
@@ -22,12 +22,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         kalign \
         tzdata \
         wget \
-        && rm -rf /var/lib/apt/lists/*
+        && rm -rf /var/lib/apt/lists/* \
+        && apt-get autoremove -y \
+        && apt-get clean
 
 # Clone AF2
 RUN git clone https://github.com/luisas/alphafold_split.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout 095768b24e9ee76a3f0f85c706f2f91cbfca659f && \
+    git checkout 3a8535cee46a35ed0462c2112e96a832eeb3f4ae && \
     cd -
 
 # Compile HHsuite from source
@@ -46,30 +48,34 @@ RUN wget -q -P /tmp \
         && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages
-RUN /conda/bin/conda update -qy conda \
+RUN /conda/bin/conda install -qy conda=4.13.0 \
     && /conda/bin/conda install -y -c conda-forge \
         openmm=7.5.1 \
-        cudatoolkit==11.1.1
+        cudatoolkit==11.1.1 \
+        pdbfixer \
+        pip \
+        python=3.7 \
+        && conda clean --all --force-pkgs-dirs --yes
 
-RUN /conda/bin/conda install -y -c conda-forge \
-        pdbfixer
-
-RUN /conda/bin/conda install -y -c conda-forge pip
-
-RUN /conda/bin/conda install -y -c conda-forge python=3.9
-
-COPY . /app/alphafold
 RUN wget -q -P /app/alphafold/alphafold/common/ \
     https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
 
-# Install pip packages.
-RUN pip3 install --upgrade pip \
-    && pip3 install -r /app/alphafold/requirements.txt \
-    && pip3 install --upgrade \
-    jaxlib==0.1.69+cuda$(cut -f1,2 -d. <<< ${CUDA} | sed 's/\.//g') \
-    -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+# Install pip packages
+RUN /conda/bin/pip3 install --upgrade pip --no-cache-dir \
+    && /conda/bin/pip3 install -r /app/alphafold/requirements.txt --no-cache-dir \
+    && /conda/bin/pip3 install --upgrade --no-cache-dir jax==0.3.17 jaxlib==0.3.15+cuda11.cudnn805 -f \
+        https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
-# # Apply OpenMM patch
-WORKDIR /conda/lib/python3.9/site-packages
+# Apply OpenMM patch
+WORKDIR /conda/lib/python3.7/site-packages
 RUN patch -p0 < /app/alphafold/docker/openmm.patch
 RUN sed -i "s|alphafold/common/stereo_chemical_props.txt|/app/alphafold/alphafold/common/stereo_chemical_props.txt|g" /app/alphafold/alphafold/common/residue_constants.py
+
+# Add SETUID bit to the ldconfig binary so that non-root users can run it.
+RUN chmod u+s /sbin/ldconfig.real
+
+# We need to run `ldconfig` first to ensure GPUs are visible, due to some quirk
+# with Debian. See https://github.com/NVIDIA/nvidia-docker/issues/1399 for
+# details.
+RUN cd /app/alphafold
+RUN ldconfig

--- a/containers/Dockerfile_AF2_split
+++ b/containers/Dockerfile_AF2_split
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 # Clone AF2
 RUN git clone https://github.com/luisas/alphafold_split.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout 3a8535cee46a35ed0462c2112e96a832eeb3f4ae && \
+    git checkout 5cb2f8c480aa8314c02a93c6fbfc3f48f0ce8af0 && \
     cd -
 
 # Compile HHsuite from source

--- a/modules/local/run_af2_msa.nf
+++ b/modules/local/run_af2_msa.nf
@@ -6,8 +6,8 @@ process RUN_AF2_MSA {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://luisas/af2_msa:v0.1' :
-        'luisas/af2_msa:v0.1' }"
+        'docker://luisas/af2_msa:2' :
+        'luisas/af2_msa:2' }"
 
     input:
     tuple val(seq_name), path(fasta)

--- a/modules/local/run_af2_pred.nf
+++ b/modules/local/run_af2_pred.nf
@@ -6,8 +6,8 @@ process RUN_AF2_PRED {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://luisas/af2_split:v.1.0' :
-        'luisas/af2_split:v.1.0' }"
+        'docker://luisas/af2_split:2' :
+        'luisas/af2_split:2' }"
 
     input:
     tuple val(seq_name), path(fasta)


### PR DESCRIPTION
Update AF2 split to version 2.2.4 (updated af2 repo  https://github.com/luisas/alphafold_split ) 

- modified dockerfiles
- new images are in DockerHub 
- containers reference changed in the workflows


<!--
# nf-core/proteinfold pull request

Many thanks for contributing to nf-core/proteinfold!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ x ] This comment contains a description of changes (with reason).
- [ x ] Make sure your code lints (`nf-core lint`).
