### PR TITLE
Set a default docker registry outside of profile scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.1.0
+## 1.1.0dev - [date]
 
 ### Enhancements & fixes
 
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update metro map to include ESMFold workflow.
 
 - Update modules to remove quay from container url.
+
+- [nf-core/tools#2286](https://github.com/nf-core/tools/issues/2286) Set default container registry outside profile scope.
 
 ## 1.0.0 - White Silver Reebok
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -162,7 +162,6 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.registry        = 'quay.io'
         docker.userEmulation   = true
         if (params.use_gpu) { docker.runOptions = '--gpus all' }
         conda.enabled          = false
@@ -192,7 +191,6 @@ profiles {
     }
     podman {
         podman.enabled         = true
-        podman.registry        = 'quay.io'
         conda.enabled          = false
         docker.enabled         = false
         singularity.enabled    = false
@@ -260,6 +258,12 @@ env {
 
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
+
+// Set default registry for Docker and Podman independent of -profile
+// Will not be used unless Docker / Podman are enabled
+// Set to your registry if you have a mirror of containers
+docker.registry = 'quay.io'
+podman.registry = 'quay.io'
 
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {


### PR DESCRIPTION
The docker.registry configuration should always be set, as running on cloud executors will need to pull docker images but will not necessarily use the docker profile. See nf-core/tools#2286

<!--
# nf-core/proteinfold pull request

Many thanks for contributing to nf-core/proteinfold!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

