### PR TITLE
Fix DOWNLOAD_PDBMMCIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
-- [#80](https://github.com/nf-core/proteinfold/pull/80) Add `accelerator` directive to GPU processes when `params.use_gpu` is true.
-- [#81](https://github.com/nf-core/proteinfold/pull/81) Support multiline fasta for colabfold multimer predictions.
-- [#89](https://github.com/nf-core/proteinfold/pull/89) Fix issue with excessive symlinking in the pdb_mmcif database.
-- [#90](https://github.com/nf-core/proteinfold/pull/90) Update pipeline template to [nf-core/tools 2.8](https://github.com/nf-core/tools/releases/tag/2.8).
-- [#91](https://github.com/nf-core/proteinfold/pull/91) Update ColabFold version to 1.5.2 and AlphaFold version to 2.3.2
-- [#92](https://github.com/nf-core/proteinfold/pull/92) Add ESMFold workflow to the pipeline.
+- [#80](https://github.com/nf-core/proteinfold/pull/80) - Add `accelerator` directive to GPU processes when `params.use_gpu` is true.
+- [#81](https://github.com/nf-core/proteinfold/pull/81) - Support multiline fasta for colabfold multimer predictions.
+- [#89](https://github.com/nf-core/proteinfold/pull/89) - Fix issue with excessive symlinking in the pdb_mmcif database.
+- [#90](https://github.com/nf-core/proteinfold/pull/90) - Update pipeline template to [nf-core/tools 2.8](https://github.com/nf-core/tools/releases/tag/2.8).
+- [#91](https://github.com/nf-core/proteinfold/pull/91) - Update ColabFold version to 1.5.2 and AlphaFold version to 2.3.2
+- [#92](https://github.com/nf-core/proteinfold/pull/92) - Add ESMFold workflow to the pipeline.
 - Update metro map to include ESMFold workflow.
 - Update modules to remove quay from container url.
-- [nf-core/tools#2286](https://github.com/nf-core/tools/issues/2286) Set default container registry outside profile scope.
-- [#97](https://github.com/nf-core/proteinfold/pull/97) Fix issue with uniref30 missing path when using the full BFD database in AlphaFold
-- [#100](https://github.com/nf-core/proteinfold/pull/100) Update containers for AlphaFold2 and ColabFold local modules
-- [#105](https://github.com/nf-core/proteinfold/pull/105) Update COLABFOLD_BATCH docker container, metro map figure and nextflow schema description
-- [#106](https://github.com/nf-core/proteinfold/pull/106) Add `singularity.registry = 'quay.io'` and bump NF version to 23.04.0
+- [nf-core/tools#2286](https://github.com/nf-core/tools/issues/2286) - Set default container registry outside profile scope.
+- [#97](https://github.com/nf-core/proteinfold/pull/97) - Fix issue with uniref30 missing path when using the full BFD database in AlphaFold.
+- [#100](https://github.com/nf-core/proteinfold/pull/100) - Update containers for AlphaFold2 and ColabFold local modules.
+- [#105](https://github.com/nf-core/proteinfold/pull/105) - Update COLABFOLD_BATCH docker container, metro map figure and nextflow schema description.
+- [#106](https://github.com/nf-core/proteinfold/pull/106) - Add `singularity.registry = 'quay.io'` and bump NF version to 23.04.0
+- [#108](https://github.com/nf-core/proteinfold/pull/108) - Fix gunzip error when providing too many files when downloading PDBMMCIF database.
 
 ## 1.0.0 - White Silver Reebok
 

--- a/modules/local/download_pdbmmcif.nf
+++ b/modules/local/download_pdbmmcif.nf
@@ -41,7 +41,7 @@ process DOWNLOAD_PDBMMCIF {
         raw
 
     echo "Unzipping all mmCIF files..."
-    find ./raw -type f -iname "*.gz" -exec gunzip {} +
+    find ./raw -type f -iname '*.gz' -exec gunzip {} +
 
     echo "Flattening all mmCIF files..."
     mkdir mmcif_files

--- a/modules/local/download_pdbmmcif.nf
+++ b/modules/local/download_pdbmmcif.nf
@@ -41,7 +41,7 @@ process DOWNLOAD_PDBMMCIF {
         raw
 
     echo "Unzipping all mmCIF files..."
-    find ./raw -type f -iname '*.gz' -exec gunzip {} +
+    find ./raw -type f -name '*.[gG][zZ]' -exec gunzip {} +
 
     echo "Flattening all mmCIF files..."
     mkdir mmcif_files


### PR DESCRIPTION
Change double quotes for single quotes in the DOWNLOAD_PDBMMCIF to avoid giving to gunzip too many files.

Fixes #108 
- [x] Make sure your code lints (`nf-core lint`).
- [x] `CHANGELOG.md` is updated.
