### PR TITLE
Fix "Argument list too long" issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
-- [#80](https://github.com/nf-core/proteinfold/pull/80) - Add `accelerator` directive to GPU processes when `params.use_gpu` is true.
-- [#81](https://github.com/nf-core/proteinfold/pull/81) - Support multiline fasta for colabfold multimer predictions.
-- [#89](https://github.com/nf-core/proteinfold/pull/89) - Fix issue with excessive symlinking in the pdb_mmcif database.
-- [PR #91](https://github.com/nf-core/proteinfold/pull/91) - Update ColabFold version to 1.5.2 and AlphaFold version to 2.3.2
-- [PR #92](https://github.com/nf-core/proteinfold/pull/92) - Add ESMFold workflow to the pipeline.
+- [[#80](https://github.com/nf-core/proteinfold/pull/80)] - Add `accelerator` directive to GPU processes when `params.use_gpu` is true.
+- [[#81](https://github.com/nf-core/proteinfold/pull/81)] - Support multiline fasta for colabfold multimer predictions.
+- [[#89](https://github.com/nf-core/proteinfold/pull/89)] - Fix issue with excessive symlinking in the pdb_mmcif database.
+- [[PR #91](https://github.com/nf-core/proteinfold/pull/91)] - Update ColabFold version to 1.5.2 and AlphaFold version to 2.3.2
+- [[PR #92](https://github.com/nf-core/proteinfold/pull/92)] - Add ESMFold workflow to the pipeline.
 - Update metro map to include ESMFold workflow.
 - Update modules to remove quay from container url.
-- [nf-core/tools#2286](https://github.com/nf-core/tools/issues/2286) - Set default container registry outside profile scope.
-- [PR #97](https://github.com/nf-core/proteinfold/pull/97) - Fix issue with uniref30 missing path when using the full BFD database in AlphaFold.
-- [PR #100](https://github.com/nf-core/proteinfold/pull/100) - Update containers for AlphaFold2 and ColabFold local modules.
-- [PR #105](https://github.com/nf-core/proteinfold/pull/105) - Update COLABFOLD_BATCH docker container, metro map figure and nextflow schema description.
-- [PR #106](https://github.com/nf-core/proteinfold/pull/106) - Add `singularity.registry = 'quay.io'` and bump NF version to 23.04.0
+- [[nf-core/tools#2286](https://github.com/nf-core/tools/issues/2286)] - Set default container registry outside profile scope.
+- [[PR #97](https://github.com/nf-core/proteinfold/pull/97)] - Fix issue with uniref30 missing path when using the full BFD database in AlphaFold.
+- [[PR #100](https://github.com/nf-core/proteinfold/pull/100)] - Update containers for AlphaFold2 and ColabFold local modules.
+- [[PR #105](https://github.com/nf-core/proteinfold/pull/105)] - Update COLABFOLD_BATCH docker container, metro map figure and nextflow schema description.
+- [[PR #106](https://github.com/nf-core/proteinfold/pull/106)] - Add `singularity.registry = 'quay.io'` and bump NF version to 23.04.0
 - [[#108](https://github.com/nf-core/proteinfold/issues/108)] - Fix gunzip error when providing too many files when downloading PDBMMCIF database.
-- [PR #111](https://github.com/nf-core/proteinfold/pull/111) - Update pipeline template to [nf-core/tools 2.9](https://github.com/nf-core/tools/releases/tag/2.9).
-- [PR #112](https://github.com/nf-core/rnaseq/pull/112) - Use `nf-validation` plugin for parameter and samplesheet validation.
-- [#113](https://github.com/nf-core/proteinfold/pull/113) - Include esmfold dbs for full data sets.
-- [PR #114](https://github.com/nf-core/rnaseq/pull/114) - Update paths to test dbs.
-- [PR #117](https://github.com/nf-core/proteinfold/pull/117) - Update pipeline template to [nf-core/tools 2.10](https://github.com/nf-core/tools/releases/tag/2.10).
+- [[PR #111](https://github.com/nf-core/proteinfold/pull/111)] - Update pipeline template to [nf-core/tools 2.9](https://github.com/nf-core/tools/releases/tag/2.9).
+- [[PR #112](https://github.com/nf-core/rnaseq/pull/112)] - Use `nf-validation` plugin for parameter and samplesheet validation.
+- [[#113](https://github.com/nf-core/proteinfold/pull/113)] - Include esmfold dbs for full data sets.
+- [[PR #114](https://github.com/nf-core/rnaseq/pull/114)] - Update paths to test dbs.
+- [[PR #117](https://github.com/nf-core/proteinfold/pull/117)] - Update pipeline template to [nf-core/tools 2.10](https://github.com/nf-core/tools/releases/tag/2.10).
 
 ## 1.0.0 - White Silver Reebok
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #100](https://github.com/nf-core/proteinfold/pull/100) - Update containers for AlphaFold2 and ColabFold local modules.
 - [PR #105](https://github.com/nf-core/proteinfold/pull/105) - Update COLABFOLD_BATCH docker container, metro map figure and nextflow schema description.
 - [PR #106](https://github.com/nf-core/proteinfold/pull/106) - Add `singularity.registry = 'quay.io'` and bump NF version to 23.04.0
-- [PR #108](https://github.com/nf-core/proteinfold/pull/108) - Fix gunzip error when providing too many files when downloading PDBMMCIF database.
+- [[#108](https://github.com/nf-core/proteinfold/issues/108)] - Fix gunzip error when providing too many files when downloading PDBMMCIF database.
 - [PR #111](https://github.com/nf-core/proteinfold/pull/111) - Update pipeline template to [nf-core/tools 2.9](https://github.com/nf-core/tools/releases/tag/2.9).
 - [PR #112](https://github.com/nf-core/rnaseq/pull/112) - Use `nf-validation` plugin for parameter and samplesheet validation.
 - [#113](https://github.com/nf-core/proteinfold/pull/113) - Include esmfold dbs for full data sets.

--- a/modules/local/download_pdbmmcif.nf
+++ b/modules/local/download_pdbmmcif.nf
@@ -41,7 +41,7 @@ process DOWNLOAD_PDBMMCIF {
         raw
 
     echo "Unzipping all mmCIF files..."
-    find ./raw -type f -name '*.[gG][zZ]' -print0 | while IFS= read -r -d $'\0' file; do
+    find ./raw -type f -name '*.[gG][zZ]' -print0 | while IFS= read -r -d \$'\\0' file; do
         gunzip "$file"
     done
 

--- a/modules/local/download_pdbmmcif.nf
+++ b/modules/local/download_pdbmmcif.nf
@@ -41,7 +41,9 @@ process DOWNLOAD_PDBMMCIF {
         raw
 
     echo "Unzipping all mmCIF files..."
-    find ./raw -type f -name '*.[gG][zZ]' -exec gunzip {} +
+    find ./raw -type f -name '*.[gG][zZ]' -print0 | while IFS= read -r -d $'\0' file; do
+        gunzip "$file"
+    done
 
     echo "Flattening all mmCIF files..."
     mkdir mmcif_files


### PR DESCRIPTION
Fixes #108 

Since the previous [fix](https://github.com/nf-core/proteinfold/issues/108) did not work, as reported on [this](https://nfcore.slack.com/archives/C0351A8S487/p1695973745423429?thread_ts=1687816183.770649&cid=C0351A8S487) slack thread, the code is changed now to run using a for loop. This should avoid getting the "Argument list too long" without modifying the `ulimit` size.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

