### PR TITLE
Call gunzip by file to avoid too argument error

### DIFF
--- a/modules/local/download_pdbmmcif.nf
+++ b/modules/local/download_pdbmmcif.nf
@@ -41,9 +41,7 @@ process DOWNLOAD_PDBMMCIF {
         raw
 
     echo "Unzipping all mmCIF files..."
-    find ./raw -type f -name '*.[gG][zZ]' -print0 | while IFS= read -r -d \$'\\0' file; do
-        gunzip "$file"
-    done
+    find ./raw -type f -name '*.[gG][zZ]' -exec gunzip {} \\;
 
     echo "Flattening all mmCIF files..."
     mkdir mmcif_files


### PR DESCRIPTION
Fix for #108, the current command should process the files one by one, thus, avoiding the `Argument list too long` error

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

