### PR TITLE
Update alphafold images and Dockerfiles

### DIFF
--- a/dockerfiles/Dockerfile_nfcore-proteinfold_alphafold2_msa
+++ b/dockerfiles/Dockerfile_nfcore-proteinfold_alphafold2_msa
@@ -1,9 +1,9 @@
-FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
-LABEL authors="Luisa Santus, Athanasios Baltzis, Leila Mansouri" \
+FROM nvidia/cuda:11.4.3-cudnn8-runtime-ubuntu18.04
+
+LABEL authors="Luisa Santus, Athanasios Baltzis, Jose Espinosa-Carrasco, Leila Mansouri" \
     title="nfcore/proteinfold_alphafold2_msa" \
     Version="1.1.0" \
     description="Docker image containing all software requirements to run the RUN_ALPHAFOLD2_MSA module using the nf-core/proteinfold pipeline"
-
 
 # Use bash to support string substitution.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 # Clone AlphaFold2
 RUN git clone https://github.com/cbcrg/alphafold.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout b35b26e0ef88cc00498a73a8dffe429a119c6ee4 && \
+    git checkout 1b3170e9409472ec8ad044f9935c92bedd7b4674 && \
     cd -
 
 # Compile HHsuite from source
@@ -48,8 +48,7 @@ RUN wget -q -P /tmp \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages
-RUN /conda/bin/conda install -qy conda=4.13.0  \
-    && /conda/bin/conda install -y -c conda-forge \
+RUN /conda/bin/conda install -y -c conda-forge \
     pip \
     python=3.10 \
     && conda clean --all --force-pkgs-dirs --yes
@@ -57,4 +56,3 @@ RUN /conda/bin/conda install -qy conda=4.13.0  \
 # Install pip packages
 RUN pip3 install --upgrade pip --no-cache-dir \
     && pip3 install -r /app/alphafold/requirements_msa.txt --no-cache-dir
-

--- a/dockerfiles/Dockerfile_nfcore-proteinfold_alphafold2_split
+++ b/dockerfiles/Dockerfile_nfcore-proteinfold_alphafold2_split
@@ -1,9 +1,9 @@
-FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
-LABEL authors="Athanasios Baltzis, Leila Mansouri" \
+FROM nvidia/cuda:11.4.3-cudnn8-runtime-ubuntu18.04
+
+LABEL authors="Athanasios Baltzis, Jose Espinosa-Carrasco, Leila Mansouri" \
     title="nfcore/proteinfold_alphafold2_split" \
     Version="1.1.0" \
     description="Docker image containing all software requirements to run the RUN_ALPHAFOLD2_PRED module using the nf-core/proteinfold pipeline"
-
 
 # Use bash to support string substitution.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 # Clone AlphaFold2
 RUN git clone https://github.com/cbcrg/alphafold.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout b35b26e0ef88cc00498a73a8dffe429a119c6ee4 && \
+    git checkout 1b3170e9409472ec8ad044f9935c92bedd7b4674 && \
     cd -
 
 # Compile HHsuite from source
@@ -48,8 +48,7 @@ RUN wget -q -P /tmp \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages
-RUN /conda/bin/conda install -qy conda=4.13.0 \
-    && /conda/bin/conda install -y -c conda-forge \
+RUN /conda/bin/conda install -y -c conda-forge \
     openmm=7.7.0 \
     cudatoolkit==11.1.1 \
     pdbfixer \
@@ -59,7 +58,6 @@ RUN /conda/bin/conda install -qy conda=4.13.0 \
 
 RUN wget -q -P /app/alphafold/alphafold/common/ \
     https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
-
 
 # Install pip packages.
 RUN pip3 install --upgrade pip --no-cache-dir \
@@ -79,4 +77,3 @@ RUN chmod u+s /sbin/ldconfig.real
 # details.
 RUN cd /app/alphafold
 RUN ldconfig
-

--- a/dockerfiles/Dockerfile_nfcore-proteinfold_alphafold2_standard
+++ b/dockerfiles/Dockerfile_nfcore-proteinfold_alphafold2_standard
@@ -1,9 +1,9 @@
-FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
-LABEL authors="Athanasios Baltzis, Leila Mansouri" \
+FROM nvidia/cuda:11.4.3-cudnn8-runtime-ubuntu18.04
+
+LABEL authors="Athanasios Baltzis, Jose Espinosa-Carrasco, Leila Mansouri" \
     title="nfcore/proteinfold_alphafold2_standard" \
     Version="1.1.0" \
     description="Docker image containing all software requirements to run the RUN_ALPHAFOLD2 module using the nf-core/proteinfold pipeline"
-
 
 # Use bash to support string substitution.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -48,8 +48,7 @@ RUN wget -q -P /tmp \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages
-RUN /conda/bin/conda install -qy conda=4.13.0 \
-    && /conda/bin/conda install -y -c conda-forge \
+RUN /conda/bin/conda install -y -c conda-forge \
     openmm=7.7.0 \
     cudatoolkit==11.1.1 \
     pdbfixer \
@@ -57,7 +56,6 @@ RUN /conda/bin/conda install -qy conda=4.13.0 \
     python=3.10 \
     && conda clean --all --force-pkgs-dirs --yes
 
-COPY . /app/alphafold
 RUN wget -q -P /app/alphafold/alphafold/common/ \
     https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
 

--- a/dockerfiles/Dockerfile_nfcore-proteinfold_alphafold2_standard
+++ b/dockerfiles/Dockerfile_nfcore-proteinfold_alphafold2_standard
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 # Clone AlphaFold2
 RUN git clone https://github.com/deepmind/alphafold.git /app/alphafold && \
     cd /app/alphafold && \
-    git checkout 6a3af1adb3bbbc53562da100e3819b2fc882f915 && \
+    git checkout 7c9114c8423ac9db981d8365168464bab09b3e54 && \
     cd -
 
 # Compile HHsuite from source
@@ -77,4 +77,3 @@ RUN chmod u+s /sbin/ldconfig.real
 # details.
 RUN cd /app/alphafold
 RUN ldconfig
-

--- a/modules/local/run_alphafold2.nf
+++ b/modules/local/run_alphafold2.nf
@@ -5,7 +5,7 @@ process RUN_ALPHAFOLD2 {
     tag "$meta.id"
     label 'process_medium'
 
-    container "nf-core/proteinfold_alphafold2_standard:1.1.0"
+    container "nf-core/proteinfold_alphafold2_standard:dev"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/local/run_alphafold2_msa.nf
+++ b/modules/local/run_alphafold2_msa.nf
@@ -5,7 +5,7 @@ process RUN_ALPHAFOLD2_MSA {
     tag   "$meta.id"
     label 'process_medium'
 
-    container "nf-core/proteinfold_alphafold2_msa:1.1.0"
+    container "nf-core/proteinfold_alphafold2_msa:dev"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/local/run_alphafold2_pred.nf
+++ b/modules/local/run_alphafold2_pred.nf
@@ -5,7 +5,7 @@ process RUN_ALPHAFOLD2_PRED {
     tag   "$meta.id"
     label 'process_medium'
 
-    container "nf-core/proteinfold_alphafold2_split:1.1.0"
+    container "nf-core/proteinfold_alphafold2_split:dev"
 
     input:
     tuple val(meta), path(fasta)


### PR DESCRIPTION
Closes #135 
Update the rest of `Dockerfiles` to use the same base image `cuda:11.4.3-cudnn8-runtime-ubuntu18.04`.