### PR TITLE
Include esmfold small tests and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,19 @@ jobs:
       - name: Run pipeline with stub-run in colabfold_webserver mode
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test_colabfold_webserver,docker --outdir ./results
+
+  test_esmfold:
+    name: Test ESMFold workflow
+    if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/proteinfold') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
+
+      - name: Install Nextflow
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Run pipeline with stub-run in esmfold mode
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} -profile test_esmfold,docker --outdir ./results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #132](https://github.com/nf-core/proteinfold/pull/132)] - Remove `lib/` directory.
 - [[#135](https://github.com/nf-core/proteinfold/issues/135)] - Reduce Alphafold Docker images sizes.
 - [[#115](https://github.com/nf-core/proteinfold/issues/115)] - Throw message error when profile conda is used.
+- [[#131](https://github.com/nf-core/proteinfold/issues/131)] - Add esmfold small tests.
 
 ## 1.0.0 - White Silver Reebok
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -137,7 +137,6 @@ try {
     System.err.println("WARNING: Could not load nf-core/config/proteinfold profiles: ${params.custom_config_base}/pipeline/proteinfold.config")
 }
 
-
 profiles {
     debug {
         dumpHashes             = true
@@ -244,6 +243,7 @@ profiles {
     test_alphafold2_split         { includeConfig 'conf/test_alphafold_split.config'                   }
     test_colabfold_local          { includeConfig 'conf/test_colabfold_local.config'                   }
     test_colabfold_webserver      { includeConfig 'conf/test_colabfold_webserver.config'               }
+    test_esmfold                  { includeConfig 'conf/test_esmfold.config'                           }
     test_full                     { includeConfig 'conf/test_full.config'                              }
     test_full_alphafold2_standard { includeConfig 'conf/test_full.config'                              }
     test_full_alphafold2_split    { includeConfig 'conf/test_full_alphafold_split.config'              }


### PR DESCRIPTION
The config for `test_esmfold` was not included in the `nextflow.config`. 
Also the test is now run from CI.

Fixes #131 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
