### PR TITLE
fix name of mmseq output channel db_indexed

### DIFF
--- a/subworkflows/local/prepare_colabfold_dbs.nf
+++ b/subworkflows/local/prepare_colabfold_dbs.nf
@@ -47,7 +47,7 @@ workflow PREPARE_COLABFOLD_DBS {
                 MMSEQS_CREATEINDEX_COLABFOLDDB (
                     MMSEQS_TSV2EXPROFILEDB_COLABFOLDDB.out.db_exprofile
                 )
-                ch_colabfold_db = MMSEQS_CREATEINDEX_COLABFOLDDB.out.db_index
+                ch_colabfold_db = MMSEQS_CREATEINDEX_COLABFOLDDB.out.db_indexed
                 ch_versions = ch_versions.mix(MMSEQS_CREATEINDEX_COLABFOLDDB.out.versions)
             }
 
@@ -66,7 +66,7 @@ workflow PREPARE_COLABFOLD_DBS {
                 MMSEQS_CREATEINDEX_UNIPROT30 (
                     MMSEQS_TSV2EXPROFILEDB_UNIPROT30.out.db_exprofile
                 )
-                ch_uniref30 = MMSEQS_CREATEINDEX_UNIPROT30.out.db_index
+                ch_uniref30 = MMSEQS_CREATEINDEX_UNIPROT30.out.db_indexed
                 ch_versions = ch_versions.mix(MMSEQS_CREATEINDEX_UNIPROT30.out.versions)
             }
         }


### PR DESCRIPTION
## PR checklist
- The change is to fix a minor bug related to the name of the output channel of mmseq under the sub-workflow [`prepare_colabfold_dbs.nf`](https://github.com/nf-core/proteinfold/blob/dev/subworkflows/local/prepare_colabfold_dbs.nf). It should be `db_indexed` instead of `db_index` as seen in the module [`mmseqs/createindex`](https://github.com/nf-core/proteinfold/tree/dev/modules/nf-core/mmseqs/createindex). 
