### PR TITLE
Create 2 different parameters for Colabfold and ESMfold number of recycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#148](https://github.com/nf-core/proteinfold/issues/148)] - Update Colabfold DBs.
 - [[PR #159](https://github.com/nf-core/proteinfold/pull/159)] - Update `mgnify` paths to new available version.
 - [[PR ##163](https://github.com/nf-core/proteinfold/pull/163)] - Fix full test CI.
+- [[#150]](https://github.com/nf-core/proteinfold/issues/150)] - Add thanks to the AWS Open Data Sponsorship program in `README.md`.
+- [[PR ##166](https://github.com/nf-core/proteinfold/pull/166)] - Create 2 different parameters for Colabfold and ESMfold number of recycles.
 
 ### Parameters
 
@@ -57,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | `--uniclust30_path`   | `--uniref30_alphafold2_path`             |
 | `--uniref30`          | `--uniref30_colabfold_link`              |
 | `--uniref30_path`     | `--uniref30_colabfold_path`              |
+| `--num_recycle`       | `--num_recycles_colabfold`               |
+|                       | `--num_recycles_esmfold`                 |
 |                       | `--uniref30_alphafold2_link`             |
 |                       | `--esmfold_db`                           |
 |                       | `--esmfold_model_preset`                 |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ nf-core/proteinfold was originally written by Athanasios Baltzis ([@athbaltzis](
 
 Many thanks to others who have helped out and contributed along the way too, including (but not limited to): Norman Goodacre and Waleed Osman from Interline Therapeutics ([@interlinetx](https://github.com/interlinetx)), Martin Steinegger ([@martin-steinegger](https://github.com/martin-steinegger)) and Raoul J.P. Bonnal ([@rjpbonnal](https://github.com/rjpbonnal))
 
+We would also like to thanks to the AWS Open Data Sponsorship Program for generously providing the resources necessary to host the data utilized in the testing, development, and deployment of nf-core proteinfold.
+
 ## Contributions and Support
 
 If you would like to contribute to this pipeline, please see the [contributing guidelines](.github/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The pipeline takes care of downloading the databases and parameters required by 
       --mode colabfold \
       --colabfold_server local \
       --colabfold_db <null (default) | PATH> \
-      --num_recycle 3 \
+      --num_recycles_colabfold 3 \
       --use_amber <true/false> \
       --colabfold_model_preset "AlphaFold2-ptm" \
       --use_gpu <true/false> \
@@ -113,7 +113,7 @@ The pipeline takes care of downloading the databases and parameters required by 
       --colabfold_server webserver \
       --host_url <custom MMSeqs2 API Server URL> \
       --colabfold_db <null (default) | PATH> \
-      --num_recycle 3 \
+      --num_recycles_colabfold 3 \
       --use_amber <true/false> \
       --colabfold_model_preset "AlphaFold2-ptm" \
       --use_gpu <true/false> \
@@ -133,7 +133,7 @@ The pipeline takes care of downloading the databases and parameters required by 
       --mode esmfold \
       --esmfold_model_preset <monomer/multimer> \
       --esmfold_db <null (default) | PATH> \
-      --num_recycles 4 \
+      --num_recycles_esmfold 4 \
       --use_gpu <true/false> \
       -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
   ```
@@ -153,8 +153,6 @@ For more details about the output files and reports, please refer to the
 ## Credits
 
 nf-core/proteinfold was originally written by Athanasios Baltzis ([@athbaltzis](https://github.com/athbaltzis)), Jose Espinosa-Carrasco ([@JoseEspinosa](https://github.com/JoseEspinosa)), Luisa Santus ([@luisas](https://github.com/luisas)) and Leila Mansouri ([@l-mansouri](https://github.com/l-mansouri)) from [The Comparative Bioinformatics Group](https://www.crg.eu/en/cedric_notredame) at [The Centre for Genomic Regulation, Spain](https://www.crg.eu/) under the umbrella of the [BovReg project](https://www.bovreg.eu/) and Harshil Patel ([@drpatelh](https://github.com/drpatelh)) from [Seqera Labs, Spain](https://seqera.io/).
-
-We thank the following people for their extensive assistance in the development of this pipeline:
 
 Many thanks to others who have helped out and contributed along the way too, including (but not limited to): Norman Goodacre and Waleed Osman from Interline Therapeutics ([@interlinetx](https://github.com/interlinetx)), Martin Steinegger ([@martin-steinegger](https://github.com/martin-steinegger)) and Raoul J.P. Bonnal ([@rjpbonnal](https://github.com/rjpbonnal))
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -234,7 +234,7 @@ nextflow run nf-core/proteinfold \
       --mode colabfold \
       --colabfold_server local \
       --colabfold_db <null (default) | DB_PATH> \
-      --num_recycle 3 \
+      --num_recycles_colabfold 3 \
       --use_amber <true/false> \
       --colabfold_model_preset "AlphaFold2-ptm" \
       --use_gpu <true/false> \
@@ -252,7 +252,7 @@ nextflow run nf-core/proteinfold \
       --colabfold_server webserver \
       --host_url <custom MMSeqs2 API Server URL> \
       --colabfold_db <null (default) | DB_PATH> \
-      --num_recycle 3 \
+      --num_recycles_colabfold 3 \
       --use_amber <true/false> \
       --colabfold_model_preset "AlphaFold2-ptm" \
       --use_gpu <true/false> \
@@ -407,7 +407,7 @@ nextflow run nf-core/proteinfold \
       --outdir <OUTDIR> \
       --mode esmfold
       --esmfold_db <null (default) | DB_PATH> \
-      --num_recycles 4 \
+      --num_recycles_esmfold 4 \
       --esmfold_model_preset <monomer/multimer> \
       --use_gpu <true/false> \
       -profile <docker>

--- a/main.nf
+++ b/main.nf
@@ -144,7 +144,7 @@ workflow NFCORE_PROTEINFOLD {
             PREPARE_COLABFOLD_DBS.out.params,
             PREPARE_COLABFOLD_DBS.out.colabfold_db,
             PREPARE_COLABFOLD_DBS.out.uniref30,
-            params.num_recycle
+            params.num_recycles_colabfold
         )
         ch_multiqc  = COLABFOLD.out.multiqc_report
         ch_versions = ch_versions.mix(COLABFOLD.out.versions)
@@ -172,7 +172,7 @@ workflow NFCORE_PROTEINFOLD {
         ESMFOLD (
             ch_versions,
             PREPARE_ESMFOLD_DBS.out.params,
-            params.num_recycle
+            params.num_recycles_esmfold
         )
         ch_multiqc  = ESMFOLD.out.multiqc_report
         ch_versions = ch_versions.mix(ESMFOLD.out.versions)

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,7 +50,7 @@ params {
     // Colabfold parameters
     colabfold_server            = "webserver"
     colabfold_model_preset      = "alphafold2_ptm" // {'auto', 'alphafold2', 'alphafold2_ptm', 'alphafold2_multimer_v1', 'alphafold2_multimer_v2', 'alphafold2_multimer_v3'}
-    num_recycle                 = 3
+    num_recycles_colabfold      = 3
     use_amber                   = true
     colabfold_db                = null
     db_load_mode                = 0
@@ -69,7 +69,7 @@ params {
     // Esmfold parameters
     esmfold_db                  = null
     esmfold_model_preset        = "monomer"
-    num_recycles                = 4
+    num_recycles_esmfold        = 4
 
     // Esmfold links
     esmfold_3B_v1                           = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -130,10 +130,10 @@
                     ],
                     "fa_icon": "fas fa-stream"
                 },
-                "num_recycle": {
+                "num_recycles_colabfold": {
                     "type": "integer",
                     "default": 3,
-                    "description": "Number of recycles",
+                    "description": "Number of recycles for Colabfold",
                     "fa_icon": "fas fa-recycle"
                 },
                 "use_amber": {
@@ -180,7 +180,7 @@
                     "description": "Specifies the PARAMS path used by 'esmfold' mode",
                     "fa_icon": "fas fa-folder-open"
                 },
-                "num_recycles": {
+                "num_recycles_esmfold": {
                     "type": "integer",
                     "default": 4,
                     "description": "Specifies the number of recycles used by Esmfold",

--- a/workflows/colabfold.nf
+++ b/workflows/colabfold.nf
@@ -45,7 +45,7 @@ workflow COLABFOLD {
     ch_colabfold_params    // channel: path(colabfold_params)
     ch_colabfold_db        // channel: path(colabfold_db)
     ch_uniref30            // channel: path(uniref30)
-    num_recycle            // int: Number of recycles for esmfold
+    num_recycles           // int: Number of recycles for esmfold
 
     main:
     ch_multiqc_files = Channel.empty()
@@ -72,7 +72,7 @@ workflow COLABFOLD {
                 ch_colabfold_params,
                 [],
                 [],
-                num_recycle
+                num_recycles
             )
             ch_versions = ch_versions.mix(COLABFOLD_BATCH.out.versions)
         } else {
@@ -82,7 +82,7 @@ workflow COLABFOLD {
                 ch_colabfold_params,
                 [],
                 [],
-                num_recycle
+                num_recycles
             )
             ch_versions = ch_versions.mix(COLABFOLD_BATCH.out.versions)
         }
@@ -122,7 +122,7 @@ workflow COLABFOLD {
             ch_colabfold_params,
             ch_colabfold_db,
             ch_uniref30,
-            num_recycle
+            num_recycles
         )
         ch_versions = ch_versions.mix(COLABFOLD_BATCH.out.versions)
     }

--- a/workflows/esmfold.nf
+++ b/workflows/esmfold.nf
@@ -41,7 +41,7 @@ workflow ESMFOLD {
     take:
     ch_versions       // channel: [ path(versions.yml) ]
     ch_esmfold_params // directory: /path/to/esmfold/params/
-    ch_num_recycle    // int: Number of recycles for esmfold
+    ch_num_recycles   // int: Number of recycles for esmfold
 
     main:
     ch_multiqc_files = Channel.empty()
@@ -64,14 +64,14 @@ workflow ESMFOLD {
         RUN_ESMFOLD(
             MULTIFASTA_TO_SINGLEFASTA.out.input_fasta,
             ch_esmfold_params,
-            ch_num_recycle
+            ch_num_recycles
         )
         ch_versions = ch_versions.mix(RUN_ESMFOLD.out.versions)
     } else {
         RUN_ESMFOLD(
             ch_fasta,
             ch_esmfold_params,
-            ch_num_recycle
+            ch_num_recycles
         )
         ch_versions = ch_versions.mix(RUN_ESMFOLD.out.versions)
     }


### PR DESCRIPTION
* Creates two different parameters for the number of recycles of Colabfold and ESMFold `num_recycles_colabfold` and `num_recycles_esmfold`.  

* Adds mention to the AWS open data sponsorship program into the readme. Closes #150 

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
