### PR TITLE
Enable running multiple modes in parallel 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
-- [[PR #175](https://github.com/nf-core/proteinfold/pull/175)] - Fix typo in some instances of model preset `alphafold2_ptm`.
+- [[#177](https://github.com/nf-core/proteinfold/issues/177)]- Fix typo in some instances of model preset `alphafold2_ptm`.
 - [[PR #178](https://github.com/nf-core/proteinfold/pull/178)] - Enable running multiple modes in parallel.
 
 ## [[1.1.1](https://github.com/nf-core/proteinfold/releases/tag/1.1.1)] - 2025-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [[PR #175](https://github.com/nf-core/proteinfold/pull/175)] - Fix typo in some instances of model preset `alphafold2_ptm`.
 
+- [[PR #178](https://github.com/nf-core/proteinfold/pull/178)] - Enable running multiple modes in parallel.
+
 ## [[1.1.1](https://github.com/nf-core/proteinfold/releases/tag/1.1.1)] - 2025-07-30
 
 ### Enhancements & fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements & fixes
 
 - [[PR #175](https://github.com/nf-core/proteinfold/pull/175)] - Fix typo in some instances of model preset `alphafold2_ptm`.
-
 - [[PR #178](https://github.com/nf-core/proteinfold/pull/178)] - Enable running multiple modes in parallel.
 
 ## [[1.1.1](https://github.com/nf-core/proteinfold/releases/tag/1.1.1)] - 2025-07-30

--- a/conf/modules_alphafold2.config
+++ b/conf/modules_alphafold2.config
@@ -17,9 +17,16 @@
 process {
     withName: 'GUNZIP|COMBINE_UNIPROT|DOWNLOAD_PDBMMCIF|ARIA2_PDB_SEQRES' {
         publishDir = [
-            path: {"${params.outdir}/DBs/${params.mode}/${params.alphafold2_mode}"},
+            path: {"${params.outdir}/DBs/alphafold2/${params.alphafold2_mode}"},
             mode: 'symlink',
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        ]
+    }
+    withName: 'NFCORE_PROTEINFOLD:ALPHAFOLD2:MULTIQC' {
+        publishDir = [
+            path: { "${params.outdir}/multiqc" },
+            mode: 'copy',
+            saveAs: { filename -> filename.equals('versions.yml') ? null : "alphafold2_$filename" }
         ]
     }
 }
@@ -33,7 +40,7 @@ if (params.alphafold2_mode == 'standard') {
                 params.max_template_date ? "--max_template_date ${params.max_template_date}" : ''
             ].join(' ').trim()
             publishDir = [
-                path: { "${params.outdir}/${params.mode}/${params.alphafold2_mode}" },
+                path: { "${params.outdir}/alphafold2/${params.alphafold2_mode}" },
                 mode: 'copy',
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
             ]
@@ -47,7 +54,7 @@ if (params.alphafold2_mode == 'split_msa_prediction') {
         withName: 'RUN_ALPHAFOLD2_MSA' {
             ext.args =  params.max_template_date ? "--max_template_date ${params.max_template_date}" : ''
             publishDir = [
-                path: { "${params.outdir}/${params.mode}/${params.alphafold2_mode}" },
+                path: { "${params.outdir}/alphafold2/${params.alphafold2_mode}" },
                 mode: 'copy',
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -57,7 +64,7 @@ if (params.alphafold2_mode == 'split_msa_prediction') {
             if(params.use_gpu) { accelerator = 1 }
             ext.args   = params.use_gpu ? '--use_gpu_relax=true' : '--use_gpu_relax=false'
             publishDir = [
-                path: { "${params.outdir}/${params.mode}/${params.alphafold2_mode}" },
+                path: { "${params.outdir}/alphafold2/${params.alphafold2_mode}" },
                 mode: 'copy',
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]

--- a/conf/modules_colabfold.config
+++ b/conf/modules_colabfold.config
@@ -10,6 +10,16 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    withName: 'NFCORE_PROTEINFOLD:COLABFOLD:MULTIQC' {
+        publishDir = [
+            path: { "${params.outdir}/multiqc" },
+            mode: 'copy',
+            saveAs: { filename -> filename.equals('versions.yml') ? null : "colabfold_$filename" }
+        ]
+    }
+}
+
 if (params.colabfold_server == 'webserver') {
     process {
         withName: 'COLABFOLD_BATCH' {
@@ -20,7 +30,7 @@ if (params.colabfold_server == 'webserver') {
                 params.host_url ? "--host-url ${params.host_url}" : ''
             ].join(' ').trim()
             publishDir = [
-                path: { "${params.outdir}/${params.mode}/${params.colabfold_server}" },
+                path: { "${params.outdir}/colabfold/${params.colabfold_server}" },
                 mode: 'copy',
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                 pattern: '*.*'
@@ -57,7 +67,7 @@ if (params.colabfold_server == 'local') {
                 params.use_templates ? '--templates' : ''
             ].join(' ').trim()
             publishDir = [
-                path: { "${params.outdir}/${params.mode}/${params.colabfold_server}" },
+                path: { "${params.outdir}/colabfold/${params.colabfold_server}" },
                 mode: 'copy',
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                 pattern: '*.*'

--- a/conf/modules_esmfold.config
+++ b/conf/modules_esmfold.config
@@ -14,7 +14,7 @@ process {
     withName: 'RUN_ESMFOLD' {
         ext.args = {params.use_gpu ? '' : '--cpu-only'}
         publishDir = [
-                path: { "${params.outdir}/colabfold" },
+                path: { "${params.outdir}/esmfold" },
                 mode: 'copy',
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                 pattern: '*.*'

--- a/conf/modules_esmfold.config
+++ b/conf/modules_esmfold.config
@@ -14,10 +14,19 @@ process {
     withName: 'RUN_ESMFOLD' {
         ext.args = {params.use_gpu ? '' : '--cpu-only'}
         publishDir = [
-                path: { "${params.outdir}/${params.mode}" },
+                path: { "${params.outdir}/colabfold" },
                 mode: 'copy',
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                 pattern: '*.*'
             ]
     }
+
+    withName: 'NFCORE_PROTEINFOLD:ESMFOLD:MULTIQC' {
+        publishDir = [
+            path: { "${params.outdir}/multiqc" },
+            mode: 'copy',
+            saveAs: { filename -> filename.equals('versions.yml') ? null : "esmfold_$filename" }
+        ]
+    }
+
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -183,9 +183,9 @@ Below you can find an indicative example of the TSV file with the pLDDT scores p
 <summary>Output files</summary>
 
 - `multiqc`
-  - multiqc_report.html: A standalone HTML file that can be viewed in your web browser.
-  - multiqc_data/: Directory containing parsed statistics from the different tools used in the pipeline.
-  - multiqc_plots/: Directory containing static images from the report in various formats.
+  - `<MODE>_multiqc_report.html`: A standalone HTML file that can be viewed in your web browser.
+  - `<MODE>_multiqc_data/`: Directory containing parsed statistics from the different tools used in the pipeline.
+  - `<MODE>_multiqc_plots/`: Directory containing static images from the report in various formats.
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,9 @@ An [example samplesheet](../assets/samplesheet.csv) has been provided with the p
 
 ## Running the pipeline
 
-The typical commands for running the pipeline on AlphaFold2, Colabfold and ESMFold modes are shown below.
+The typical commands for running the pipeline on AlphaFold2, Colabfold and ESMFold modes are shown below. 
+
+> You can run any combination of the models by providing them to the `--mode` parameter separated by a comma. For example: `--mode alphafold2,esmfold,colabfold` will run the three models in parallel.
 
 AlphaFold2 regular can be run using this command:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,7 @@ An [example samplesheet](../assets/samplesheet.csv) has been provided with the p
 
 ## Running the pipeline
 
-The typical commands for running the pipeline on AlphaFold2, Colabfold and ESMFold modes are shown below. 
+The typical commands for running the pipeline on AlphaFold2, Colabfold and ESMFold modes are shown below.
 
 > You can run any combination of the models by providing them to the `--mode` parameter separated by a comma. For example: `--mode alphafold2,esmfold,colabfold` will run the three models in parallel.
 

--- a/main.nf
+++ b/main.nf
@@ -20,11 +20,11 @@ nextflow.enable.dsl = 2
 if (params.mode.toLowerCase().split(",").contains("alphafold2")) {
     include { PREPARE_ALPHAFOLD2_DBS } from './subworkflows/local/prepare_alphafold2_dbs'
     include { ALPHAFOLD2             } from './workflows/alphafold2'
-} 
+}
 if (params.mode.toLowerCase().split(",").contains("colabfold")) {
     include { PREPARE_COLABFOLD_DBS } from './subworkflows/local/prepare_colabfold_dbs'
     include { COLABFOLD             } from './workflows/colabfold'
-} 
+}
 if (params.mode.toLowerCase().split(",").contains("esmfold")) {
     include { PREPARE_ESMFOLD_DBS } from './subworkflows/local/prepare_esmfold_dbs'
     include { ESMFOLD             } from './workflows/esmfold'

--- a/main.nf
+++ b/main.nf
@@ -17,13 +17,15 @@ nextflow.enable.dsl = 2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-if (params.mode == "alphafold2") {
+if (params.mode.toLowerCase().split(",").contains("alphafold2")) {
     include { PREPARE_ALPHAFOLD2_DBS } from './subworkflows/local/prepare_alphafold2_dbs'
     include { ALPHAFOLD2             } from './workflows/alphafold2'
-} else if (params.mode == "colabfold") {
+} 
+if (params.mode.toLowerCase().split(",").contains("colabfold")) {
     include { PREPARE_COLABFOLD_DBS } from './subworkflows/local/prepare_colabfold_dbs'
     include { COLABFOLD             } from './workflows/colabfold'
-} else if (params.mode == "esmfold") {
+} 
+if (params.mode.toLowerCase().split(",").contains("esmfold")) {
     include { PREPARE_ESMFOLD_DBS } from './subworkflows/local/prepare_esmfold_dbs'
     include { ESMFOLD             } from './workflows/esmfold'
 }
@@ -60,7 +62,7 @@ workflow NFCORE_PROTEINFOLD {
     //
     // WORKFLOW: Run alphafold2
     //
-    if(params.mode == "alphafold2") {
+    if(params.mode.toLowerCase().split(",").contains("alphafold2")) {
         //
         // SUBWORKFLOW: Prepare Alphafold2 DBs
         //
@@ -118,7 +120,7 @@ workflow NFCORE_PROTEINFOLD {
     //
     // WORKFLOW: Run colabfold
     //
-    else if(params.mode == "colabfold") {
+    if(params.mode.toLowerCase().split(",").contains("colabfold")) {
         //
         // SUBWORKFLOW: Prepare Colabfold DBs
         //
@@ -153,7 +155,7 @@ workflow NFCORE_PROTEINFOLD {
     //
     // WORKFLOW: Run esmfold
     //
-    else if(params.mode == "esmfold") {
+    if(params.mode.toLowerCase().split(",").contains("esmfold")) {
         //
         // SUBWORKFLOW: Prepare esmfold DBs
         //

--- a/nextflow.config
+++ b/nextflow.config
@@ -330,11 +330,13 @@ manifest {
 includeConfig 'conf/modules.config'
 
 // Load modules config for pipeline specific modes
-if (params.mode == 'alphafold2') {
+if (params.mode.toLowerCase().split(",").contains("alphafold2")) {
     includeConfig 'conf/modules_alphafold2.config'
-} else if (params.mode == 'colabfold') {
+} 
+if (params.mode.toLowerCase().split(",").contains("colabfold")) {
     includeConfig 'conf/modules_colabfold.config'
-} else if (params.mode == 'esmfold') {
+} 
+if (params.mode.toLowerCase().split(",").contains("esmfold")) {
     includeConfig 'conf/modules_esmfold.config'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -332,10 +332,10 @@ includeConfig 'conf/modules.config'
 // Load modules config for pipeline specific modes
 if (params.mode.toLowerCase().split(",").contains("alphafold2")) {
     includeConfig 'conf/modules_alphafold2.config'
-} 
+}
 if (params.mode.toLowerCase().split(",").contains("colabfold")) {
     includeConfig 'conf/modules_colabfold.config'
-} 
+}
 if (params.mode.toLowerCase().split(",").contains("esmfold")) {
     includeConfig 'conf/modules_esmfold.config'
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -32,8 +32,7 @@
                 "mode": {
                     "type": "string",
                     "default": "alphafold2",
-                    "description": "Specifies the mode in which the pipeline will be run",
-                    "enum": ["alphafold2", "colabfold", "esmfold"],
+                    "description": "Specifies the mode in which the pipeline will be run. mode can be any combination of ['alphafold2', 'colabfold', 'esmfold'] separated by a comma (',') with no spaces.",
                     "fa_icon": "fas fa-cogs"
                 },
                 "use_gpu": {

--- a/tower.yml
+++ b/tower.yml
@@ -1,5 +1,9 @@
 reports:
-  multiqc_report.html:
-    display: "MultiQC HTML report"
+  esmfold_multiqc_report.html:
+    display: "ESMFOLD MultiQC HTML report"
+  alphafold2_multiqc_report.html:
+    display: "ALPHAFOLD2 MultiQC HTML report"
+  colabfold_multiqc_report.html:
+    display: "COLABFOLD MultiQC HTML report"
   samplesheet.csv:
     display: "Auto-created samplesheet with collated metadata and FASTQ paths"


### PR DESCRIPTION
This pull request includes all changes needed to run multiple modes in parallel. the param `--mode`` now accepts multiple modes separated by a comma and runs them on the same samples in parallel.

Closes #177 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfold _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
