### PR TITLE
Fix ESMFold crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [[PR ##163](https://github.com/nf-core/proteinfold/pull/163)] - Fix full test CI.
 - [[#150]](https://github.com/nf-core/proteinfold/issues/150)] - Add thanks to the AWS Open Data Sponsorship program in `README.md`.
 - [[PR ##166](https://github.com/nf-core/proteinfold/pull/166)] - Create 2 different parameters for Colabfold and ESMfold number of recycles.
+- [[PR #222](https://github.com/nf-core/proteinfold/pull/222)] - Fix issue where ESMFold will crash if sample name does not match it's file name
 
 ### Parameters
 

--- a/modules/local/run_esmfold.nf
+++ b/modules/local/run_esmfold.nf
@@ -14,7 +14,7 @@ process RUN_ESMFOLD {
     val numRec
 
     output:
-    path ("${fasta.baseName}*.pdb"), emit: pdb
+    path ("*.pdb"), emit: pdb
     path ("${fasta.baseName}_plddt_mqc.tsv"), emit: multiqc
     path "versions.yml", emit: versions
 
@@ -33,7 +33,8 @@ process RUN_ESMFOLD {
         --num-recycles ${numRec} \
         $args
 
-    awk '{print \$2"\\t"\$3"\\t"\$4"\\t"\$6"\\t"\$11}' "${fasta.baseName}"*.pdb | grep -v 'N/A' | uniq > plddt.tsv
+    SAMPLE_NAME=\$(head -n 1 ${fasta} | cut -d ' ' -f 1 | sed 's/>//')
+    awk '{print \$2"\\t"\$3"\\t"\$4"\\t"\$6"\\t"\$11}' "\$SAMPLE_NAME"*.pdb | grep -v 'N/A' | uniq > plddt.tsv
     echo -e Atom_serial_number"\\t"Atom_name"\\t"Residue_name"\\t"Residue_sequence_number"\\t"pLDDT > header.tsv
     cat header.tsv plddt.tsv > "${fasta.baseName}"_plddt_mqc.tsv
 


### PR DESCRIPTION
This PR fixes an issue with ESMFold where the pipeline will crash if the basename of the input FASTA does not match the sample name within the FASTA.