### PR TITLE
Update dbs.config to correct pdb_mmcif_path

### DIFF
--- a/conf/dbs.config
+++ b/conf/dbs.config
@@ -28,7 +28,7 @@ params {
     alphafold2_params_path   = "${params.alphafold2_db}/alphafold_params_*/*"
     mgnify_path              = "${params.alphafold2_db}/mgnify/*"
     pdb70_path               = "${params.alphafold2_db}/pdb70/**"
-    pdb_mmcif_path           = "${params.alphafold2_db}/pdb_mmcif/*"
+    pdb_mmcif_path           = "${params.alphafold2_db}/pdb_mmcif/mmcif_files/*"
     pdb_obsolete_path        = "${params.alphafold2_db}/pdb_mmcif/obsolete.dat"
     uniref30_alphafold2_path = "${params.alphafold2_db}/uniref30/*"
     uniref90_path            = "${params.alphafold2_db}/uniref90/*"


### PR DESCRIPTION
This PR updates dbs.config to ensure proper staging and splitting of the mmcif files and obsolete.dat file for alphafold2 by modifying the pdb_mmcif_path variable. Prior to fix the process was duplicating the obselete.dat file within the mmcifs_files folder

Why This is Needed:
mmCIF files were not properly staged, causing failures during the pipeline execution.
The update ensures that all required files are correctly referenced and available.

Related Issues:
 Fixes #240.

Testing & Validation:
Successfully tested with the updated path, ensuring proper file staging.
No impact on other configurations.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfold _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
