### PR TITLE
fix wrong variable deletion from run_alphafold2_pred

### DIFF
--- a/workflows/alphafold2.nf
+++ b/workflows/alphafold2.nf
@@ -118,7 +118,7 @@ workflow ALPHAFOLD2 {
 
         RUN_ALPHAFOLD2_PRED (
             ch_samplesheet,
-            full_dbs,
+			alphafold2_model_preset,
             ch_alphafold2_params,
             ch_bfd,
             ch_small_bfd,

--- a/workflows/alphafold2.nf
+++ b/workflows/alphafold2.nf
@@ -118,7 +118,7 @@ workflow ALPHAFOLD2 {
 
         RUN_ALPHAFOLD2_PRED (
             ch_samplesheet,
-			alphafold2_model_preset,
+            alphafold2_model_preset,
             ch_alphafold2_params,
             ch_bfd,
             ch_small_bfd,


### PR DESCRIPTION
#283 removed the alphafold2_model_preset argument from the call to run_alphafold2_pred but not from the function definition (removing db_preset from function definition). Instead the full_dbs argument should have been deleted.

run_alphafold2_pred will not run with this bug since a bool is passed to the internal model_preset argument which is invalid.

This PR is a tiny bugfix which fixes this issue.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
