### PR TITLE
Change html report color scheme to be consistent with standard

### DIFF
--- a/assets/comparison_template.html
+++ b/assets/comparison_template.html
@@ -227,7 +227,7 @@
           class="hidden absolute top-0 right-0 m-6 py-6 px-10 shadow-md bg-gray-700 bg-opacity-40 text-white text-sm rounded leading-loose"
         ></div>
         <!-- Canvas buttons -->
-        <div id="canvas_button_container" class="flex-1 p-6 flex justify-center items-end bg-black gap-6 z-30"></div>
+        <div id="canvas_button_container" class="flex-1 p-6 flex justify-center items-end bg-white gap-6 z-30"></div>
         <!-- <div class="text-white mx-auto font-semibold pb-4">The top-ranked structures predicted by Alphafold</div> -->
       </div>
       <!-- Right panel -->
@@ -262,7 +262,7 @@
           <div class="text-2xl font-bold tracking-tight text-gray-900">Display</div>
           <div class="mt-2 flex flex-wrap gap-3">
             <button
-              class="btn selected w-28 rounded-md bg-white border border-gray-300 py-3 text-sm font-semibold text-gray-800 shadow-md hover:border-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
+              class="btn w-28 rounded-md bg-white border border-gray-300 py-3 text-sm font-semibold text-gray-800 shadow-md hover:border-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
               id="btn-toggle-spin"
               onclick="toggleSpin()"
             >
@@ -270,7 +270,7 @@
               Spin
             </button>
             <button
-              class="btn w-28 rounded-md bg-white border border-gray-300 py-3 text-sm font-semibold text-gray-800 shadow-md hover:border-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
+              class="btn selected w-28 rounded-md bg-white border border-gray-300 py-3 text-sm font-semibold text-gray-800 shadow-md hover:border-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
               id="btn-toggle-dark"
               onclick="toggleDark()"
             >
@@ -473,8 +473,8 @@
     let state = {
       models: [],
       colorScheme: "bfactor",
-      darkMode: true,
-      spin: true,
+      darkMode: false,
+      spin: false,
       loading: 1,
       selectedTab: 0,
     };
@@ -488,7 +488,7 @@
       // NGL.setDebug(true)
 
       // Create NGL Stage object
-      stage = new NGL.Stage("ngl-root", { backgroundColor: "black" });
+      stage = new NGL.Stage("ngl-root", { backgroundColor: "white" });
 
       // Handle window resizing
       window.addEventListener("resize", () => stage.handleResize());

--- a/assets/comparison_template.html
+++ b/assets/comparison_template.html
@@ -39,15 +39,24 @@
         --tw-bg-opacity: 1;
         color: rgb(99 102 241 / var(--tw-bg-opacity));
       }
-      .color {
-        justify-content: space-between;
-        background: linear-gradient(
-          90deg,
-          rgba(255, 55, 0, 1) 0%,
-          rgba(216, 224, 6, 1) 33%,
-          rgba(34, 213, 238, 1) 66%,
-          rgba(3, 30, 148, 1) 100%
-        );
+      .color_orange {
+        background-color: 
+          rgba(255, 165, 0, 1);
+      }
+      .color_yellow {
+        background-color: 
+          rgba(255, 255, 0, 1);
+      }
+      .color_cyan {
+        background-color: 
+          rgba(0, 255, 255, 1);
+      }
+      .color_blue {
+        background-color: 
+          rgba(0, 0, 255, 1);
+      }
+      .column {
+        float: left;
       }
     </style>
   </head>
@@ -170,30 +179,48 @@
           id="confidence-panel"
           class="hidden absolute w-56 top-0 right-0 m-6 p-6 shadow-md bg-gray-700 bg-opacity-40 rounded z-40"
         >
-          <div class="flex justify-center">
-            <div class="w-44">
-              <div class="color h-6"></div>
-              <div class="flex justify-between mt-2 text-white">
-                <div>&lt;50</div>
-                <div>70</div>
-                <div>90+</div>
+        <div class="flex justify-center">
+          <div class="w-44">
+            <div class="w-44 h-7">
+              <div class="color_blue w-16 h-6 column"></div>
+              <div class="column text-white span ml-2">
+                <div>Very High</div>
+              </div>
+            </div>
+            <div class="w-44 h-7">
+              <div class="color_cyan w-16 h-6 column"></div>
+              <div class="column text-white span ml-2">
+                <div>High</div>
+              </div>
+            </div>
+            <div class="w-44 h-7">
+              <div class="color_yellow w-16 h-6 column"></div>
+              <div class="column text-white span ml-2">
+                <div>Low</div>
+              </div>
+            </div>
+            <div class="w-44 h-7">
+              <div class="color_orange w-16 h-6 column"></div>
+              <div class="column text-white span ml-2">
+                <div>Very Low</div>
               </div>
             </div>
           </div>
-          <div class="mt-8">
-            <p class="text-sm text-white">
-              Alphafold produces a
-              <a
-                class="text-indigo-500 hover:text-indigo-400 hover:underline hover:decoration-dotted"
-                href="https://alphafold.ebi.ac.uk/faq#faq-5"
-                target="_blank"
-              >
-                per-residue confidence score (pLDDT)
-              </a>
-              between 0 and 100. Some regions below 50 pLDDT may be unstructured in isolation.
-            </p>
-          </div>
         </div>
+        <div class="mt-2">
+          <p class="text-sm text-white">
+            Alphafold produces a
+            <a
+              class="text-indigo-400 hover:text-indigo-300 hover:underline hover:decoration-dotted"
+              href="https://alphafold.ebi.ac.uk/faq#faq-5"
+              target="_blank"
+            >
+              per-residue confidence score (pLDDT)
+            </a>
+            between 0 and 100. Some regions below 50 pLDDT may be unstructured in isolation.
+          </p>
+        </div>
+      </div>
         <!-- Legend -->
         <div
           id="legend"
@@ -397,14 +424,19 @@
       this.atomColor = function (atom) {
         // Actually model confidence (pLDDT)
         const c = atom.bfactor;
-        const BREAK_RED = 40; // Below this is just plain red
-        let range, r, g, b;
+        const BREAK_ORANGE = 50; // Below this is orange
+        const BREAK_YELLOW = 70; // Below this is yellow
+        const BREAK_CYAN = 90; // Below this is cyan
 
-        if (c < BREAK_RED) {
-          return 0xff0000;
+        if (c < BREAK_ORANGE) {
+          return 0xffa500;
+        } else if (c < BREAK_YELLOW) {
+          return 0xffff00
+        } else if (c < BREAK_CYAN) {
+          return 0x00ffff
+        } else {
+          return 0x0000ff
         }
-        const p = (c - BREAK_RED) / (100 - BREAK_RED);
-        return eval(colorScale(p).hex().replace("#", "0x"));
       };
     });
 

--- a/assets/report_template.html
+++ b/assets/report_template.html
@@ -39,15 +39,24 @@
         --tw-bg-opacity: 1;
         color: rgb(99 102 241 / var(--tw-bg-opacity));
       }
-      .color {
-        justify-content: space-between;
-        background: linear-gradient(
-          90deg,
-          rgba(255, 55, 0, 1) 0%,
-          rgba(216, 224, 6, 1) 33%,
-          rgba(34, 213, 238, 1) 66%,
-          rgba(3, 30, 148, 1) 100%
-        );
+      .color_orange {
+        background-color: 
+          rgba(255, 165, 0, 1);
+      }
+      .color_yellow {
+        background-color: 
+          rgba(255, 255, 0, 1);
+      }
+      .color_cyan {
+        background-color: 
+          rgba(0, 255, 255, 1);
+      }
+      .color_blue {
+        background-color: 
+          rgba(0, 0, 255, 1);
+      }
+      .column {
+        float: left;
       }
       .ngl-viewport {
         position: absolute;
@@ -179,19 +188,37 @@
         </div>
         <!-- Model confidence -->
         <div
-          class="absolute w-56 top-0 left-0 m-6 p-6 shadow-md bg-gray-700 bg-opacity-40 rounded hover:cursor-pointer hover:h-64 overflow-hidden h-24 transition-all ease-in-out duration-200 z-40"
+          class="absolute w-56 top-0 left-0 m-6 p-3 shadow-md bg-gray-700 bg-opacity-40 rounded hover:cursor-pointer hover:h-64 overflow-hidden h-32 transition-all ease-in-out duration-200 z-40"
         >
           <div class="flex justify-center">
             <div class="w-44">
-              <div class="color h-6"></div>
-              <div class="flex justify-between mt-2 text-white">
-                <div>&lt;50</div>
-                <div>70</div>
-                <div>90+</div>
+              <div class="w-44 h-7">
+                <div class="color_blue w-16 h-6 column"></div>
+                <div class="column text-white span ml-2">
+                  <div>Very High</div>
+                </div>
+              </div>
+              <div class="w-44 h-7">
+                <div class="color_cyan w-16 h-6 column"></div>
+                <div class="column text-white span ml-2">
+                  <div>High</div>
+                </div>
+              </div>
+              <div class="w-44 h-7">
+                <div class="color_yellow w-16 h-6 column"></div>
+                <div class="column text-white span ml-2">
+                  <div>Low</div>
+                </div>
+              </div>
+              <div class="w-44 h-7">
+                <div class="color_orange w-16 h-6 column"></div>
+                <div class="column text-white span ml-2">
+                  <div>Very Low</div>
+                </div>
               </div>
             </div>
           </div>
-          <div class="mt-8">
+          <div class="mt-2">
             <p class="text-sm text-white">
               Alphafold produces a
               <a
@@ -503,20 +530,23 @@
       }
     }
 
-    const colorScale = chroma.scale(["red", "yellow", "green", "cyan", "blue"]).mode("lab").domain([0, 0.9]);
-
     const confidenceScheme = NGL.ColormakerRegistry.addScheme(function (params) {
       this.atomColor = function (atom) {
         // Actually model confidence (pLDDT)
         const c = atom.bfactor;
-        const BREAK_RED = 40; // Below this is just plain red
-        let range, r, g, b;
+        const BREAK_ORANGE = 50; // Below this is orange
+        const BREAK_YELLOW = 70; // Below this is yellow
+        const BREAK_CYAN = 90; // Below this is cyan
 
-        if (c < BREAK_RED) {
-          return 0xff0000;
+        if (c < BREAK_ORANGE) {
+          return 0xffa500;
+        } else if (c < BREAK_YELLOW) {
+          return 0xffff00
+        } else if (c < BREAK_CYAN) {
+          return 0x00ffff
+        } else {
+          return 0x0000ff //blue
         }
-        const p = (c - BREAK_RED) / (100 - BREAK_RED);
-        return eval(colorScale(p).hex().replace("#", "0x"));
       };
     });
 

--- a/assets/report_template.html
+++ b/assets/report_template.html
@@ -286,7 +286,7 @@
           </span>
         </button>
         <!-- Canvas buttons -->
-        <div id="canvas_button_container" class="flex-1 p-6 flex justify-center items-end bg-black gap-6 z-40"></div>
+        <div id="canvas_button_container" class="flex-1 p-6 flex justify-center items-end bg-white gap-6 z-40"></div>
         <!-- <div class="text-white mx-auto font-semibold pb-4">The top-ranked structures predicted by Alphafold</div> -->
       </div>
       <!-- Right panel -->
@@ -380,7 +380,7 @@
                 <div class="text-2xl font-bold tracking-tight text-gray-900">Display</div>
                 <div class="mt-2 flex flex-wrap gap-3">
                   <button
-                    class="btn selected w-28 rounded-md bg-white border border-gray-300 py-3 text-sm font-semibold text-gray-800 shadow-md hover:border-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
+                    class="btn w-28 rounded-md bg-white border border-gray-300 py-3 text-sm font-semibold text-gray-800 shadow-md hover:border-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
                     id="btn-toggle-spin"
                     onclick="toggleSpin()"
                   >
@@ -388,7 +388,7 @@
                     Spin
                   </button>
                   <button
-                    class="btn w-28 rounded-md bg-white border border-gray-300 py-3 text-sm font-semibold text-gray-800 shadow-md hover:border-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
+                    class="btn selected w-28 rounded-md bg-white border border-gray-300 py-3 text-sm font-semibold text-gray-800 shadow-md hover:border-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
                     id="btn-toggle-dark"
                     onclick="toggleDark()"
                   >
@@ -586,9 +586,9 @@
       modelObject: null,
       representations: {},
       colorScheme: "bfactor",
-      darkMode: true,
+      darkMode: false,
       loading: 1,
-      spin: true,
+      spin: false,
     };
 
     const uri = (i) => MODELS_DATA[i];
@@ -600,7 +600,7 @@
       // NGL.setDebug(true)
 
       // Create NGL Stage object
-      stage = new NGL.Stage("ngl-root", { backgroundColor: "black" });
+      stage = new NGL.Stage("ngl-root", { backgroundColor: "white" });
 
       // Handle window resizing
       window.addEventListener("resize", () => stage.handleResize());
@@ -680,7 +680,7 @@
         const promise = new Promise((resolve, reject) => {
           const stringBlob = new Blob([uri(index)], { type: "text/plain" });
           const stage = new NGL.Stage(`viewport${index}`, {
-            backgroundColor: "black",
+            backgroundColor: "white",
           });
           stages.push(stage);
 
@@ -834,7 +834,7 @@
       MODELS.forEach((model, index) => {
         const button = document.createElement("button");
         button.className =
-          "selected group btn btn-canvas w-24 rounded bg-black text-sm font-semibold text-white hover:text-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800";
+          "selected group btn btn-canvas w-24 rounded bg-white text-sm font-semibold text-white hover:text-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800";
         button.id = `btn-${model.split(".")[0]}`;
         button.onclick = () => setModel(index);
         button.innerHTML = `


### PR DESCRIPTION
Closes #272 

Modified the html report and comparison report to:
- Change color scheme to standard Alphafold coloring
- Change legend to show discrete coloring
- Change default viewer background

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
