### PR TITLE
Dowgrade schema version to 2.2.0 to pass CI test with Nextflow edge version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#281](https://github.com/nf-core/proteinfold/issues/281)] - Fix how argument `--nv` is passed to apptainer and singularity in the config.
 - [[PR #283](https://github.com/nf-core/proteinfold/pull/283)] - Fixes to meet language server requirements and update link of the helixfold3 image.
 - [[PR #287](https://github.com/nf-core/proteinfold/pull/287)] - Fixes symlinking of every mmcif file causing excess I/O.
-- [[PR #294](https://github.com/nf-core/proteinfold/pull/294)] - Temporary fix for passing CI tests with Nextflow edge version.
+- [[PR #294](https://github.com/nf-core/proteinfold/pull/294)] - Temporary downgrade of schema for passing CI tests with Nextflow edge version.
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#281](https://github.com/nf-core/proteinfold/issues/281)] - Fix how argument `--nv` is passed to apptainer and singularity in the config.
 - [[PR #283](https://github.com/nf-core/proteinfold/pull/283)] - Fixes to meet language server requirements and update link of the helixfold3 image.
 - [[PR #287](https://github.com/nf-core/proteinfold/pull/287)] - Fixes symlinking of every mmcif file causing excess I/O.
+- [[PR #294](https://github.com/nf-core/proteinfold/pull/294)] - Temporary fix for passing CI tests with Nextflow edge version.
 
 ### Parameters
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -409,8 +409,10 @@ manifest {
 }
 
 // Nextflow plugins
+// Temporary fix for CI to pass with nextflow edge version until fix
+// TODO: Update schema version again when fixed
 plugins {
-    id 'nf-schema@2.3.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.2.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
See [this](https://nfcore.slack.com/archives/C04QR0T3G3H/p1745504826926699) slack thread.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
