### PR TITLE
Fix comparison report to correctly label msa coverage plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #294](https://github.com/nf-core/proteinfold/pull/294)] - Temporary downgrade of schema for passing CI tests with Nextflow edge version.
 - [[#272](https://github.com/nf-core/proteinfold/issues/272)] - Colouring scheme conforming to AlphaFold2 confidence bands in html report.
 - [[PR #297](https://github.com/nf-core/proteinfold/pull/297)] - Update pipeline template to [nf-core/tools 3.2.1](https://github.com/nf-core/tools/releases/tag/3.2.1).
+- [[PR #298](https://github.com/nf-core/proteinfold/pull/298)] - Fixes comparison report to correctly label msa coverage plots with corresponding method label.
 
 ### Parameters
 

--- a/assets/comparison_template.html
+++ b/assets/comparison_template.html
@@ -441,6 +441,7 @@
 
     const LDDT_AVERAGES = [];
     const SEQ_COV_IMGS = [];
+    const SEQ_COV_METHODS = [];
     const MODELS = [];
 
     const MODELS_DATA = [
@@ -800,13 +801,7 @@
 
         const label = document.createElement("div");
         label.className = "font-semibold mb-2";
-
-        if (MODELS[index].includes("colabfold")) {
-          if (!MODELS[index + 1]) return;
-          label.textContent = MODELS[index + 1].replace(".pdb", "");
-        } else {
-          label.textContent = MODELS[index].replace(".pdb", "");
-        }
+        label.textContent = SEQ_COV_METHODS[index];
 
         const imgContainer = document.createElement("div");
         imgContainer.className = "w-[660px] h-auto p-6 bg-white shadow-md rounded items-center";


### PR DESCRIPTION
Closes #273 

- Modified comparison_report template to accept labels for msa_coverage plots
- Modified generate_comparison_report to provide msa_coverage plot labels from the corresponding pdb name
- Fixed bug where pdb name and msa plot were out of sync due to sorting list of pdbs.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).