### PR TITLE
Fix HF3 dbs and max_template_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #294](https://github.com/nf-core/proteinfold/pull/294)] - Temporary downgrade of schema for passing CI tests with Nextflow edge version.
 - [[#272](https://github.com/nf-core/proteinfold/issues/272)] - Colouring scheme conforming to AlphaFold2 confidence bands in html report.
 - [[PR #297](https://github.com/nf-core/proteinfold/pull/297)] - Update pipeline template to [nf-core/tools 3.2.1](https://github.com/nf-core/tools/releases/tag/3.2.1).
+- [[PR #302](https://github.com/nf-core/proteinfold/pull/302)] - Fix HF3 dbs and max_template_date.
 
 ### Parameters
 

--- a/conf/dbs.config
+++ b/conf/dbs.config
@@ -74,7 +74,7 @@ params {
     helixfold3_uniref90_link            = 'ftp://ftp.uniprot.org/pub/databases/uniprot/uniref/uniref90/uniref90.fasta.gz'
     helixfold3_mgnify_link              = 'https://storage.googleapis.com/alphafold-databases/casp14_versions/mgy_clusters_2018_12.fa.gz'
     helixfold3_pdb_mmcif_link           = 'rsync.rcsb.org::ftp_data/structures/divided/mmCIF/'
-    helixfold3_obsolete_link            = 'ftp://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat'
+    helixfold3_obsolete_link            = 'https://files.rcsb.org/pub/pdb/data/status/obsolete.dat'
 
     // Helixfold3 paths
     helixfold3_uniclust30_path          = "${params.helixfold3_db}/uniclust30/*"

--- a/conf/dbs.config
+++ b/conf/dbs.config
@@ -74,7 +74,7 @@ params {
     helixfold3_uniref90_link            = 'ftp://ftp.uniprot.org/pub/databases/uniprot/uniref/uniref90/uniref90.fasta.gz'
     helixfold3_mgnify_link              = 'https://storage.googleapis.com/alphafold-databases/casp14_versions/mgy_clusters_2018_12.fa.gz'
     helixfold3_pdb_mmcif_link           = 'rsync.rcsb.org::ftp_data/structures/divided/mmCIF/'
-    helixfold3_pdb_obsolete_link        = 'ftp://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat'
+    helixfold3_obsolete_link            = 'ftp://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat'
 
     // Helixfold3 paths
     helixfold3_uniclust30_path          = "${params.helixfold3_db}/uniclust30/*"
@@ -87,7 +87,8 @@ params {
     helixfold3_pdb_seqres_path          = "${params.helixfold3_db}/pdb_seqres/*"
     helixfold3_uniref90_path            = "${params.helixfold3_db}/uniref90/*"
     helixfold3_mgnify_path              = "${params.helixfold3_db}/mgnify/*"
-    helixfold3_pdb_mmcif_path           = "${params.helixfold3_db}/pdb_mmcif/*"
+    helixfold3_pdb_mmcif_path           = "${params.helixfold3_db}/pdb_mmcif/mmcif_files"
+    helixfold3_obsolete_path            = "${params.helixfold3_db}/pdb_mmcif/obsolete.dat"
     helixfold3_maxit_src_path           = "${params.helixfold3_db}/maxit-v11.200-prod-src"
 
     // Esmfold links

--- a/conf/modules_helixfold3.config
+++ b/conf/modules_helixfold3.config
@@ -24,7 +24,7 @@ process {
         accelerator = params.use_gpu ?  1 : 0
 
         ext.args = [
-            params.helixfold3_max_template_date ? "--helixfold3_max_template_date=${params.helixfold3_max_template_date}" : "--helixfold3_max_template_date=2024-08-14",
+            params.helixfold3_max_template_date ? "--max_template_date=${params.helixfold3_max_template_date}" : "--max_template_date=2038-01-19",
             params.model_name        ? "--model_name ${params.model_name}"               : "--model_name allatom_demo",
             params.preset            ? "--preset ${params.preset}"                       : "--preset 'reduced_dbs'",
             params.init_model        ? "--init_model ${params.init_model}"               : "--init_model './init_models/HelixFold3-240814.pdparams'",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -441,7 +441,7 @@ nextflow run nf-core/proteinfold \
 
 ```console
 ## Optional parameters with default values:
-    --helixfold3_max_template_date=2024-08-14
+    --helixfold3_max_template_date=2038-01-19
     --model_name allatom_demo
     --preset 'reduced_dbs'
     --init_model './init_models/HelixFold3-240814.pdparams'

--- a/main.nf
+++ b/main.nf
@@ -276,7 +276,7 @@ workflow NFCORE_PROTEINFOLD {
             params.helixfold3_uniref90_link,
             params.helixfold3_mgnify_link,
             params.helixfold3_pdb_mmcif_link,
-            params.helixfold3_pdb_obsolete_link,
+            params.helixfold3_obsolete_link,
             params.helixfold3_uniclust30_path,
             params.helixfold3_ccd_preprocessed_path,
             params.helixfold3_rfam_path,
@@ -288,6 +288,7 @@ workflow NFCORE_PROTEINFOLD {
             params.helixfold3_uniref90_path,
             params.helixfold3_mgnify_path,
             params.helixfold3_pdb_mmcif_path,
+            params.helixfold3_obsolete_path,
             params.helixfold3_maxit_src_path
         )
         ch_versions = ch_versions.mix(PREPARE_HELIXFOLD3_DBS.out.versions)
@@ -307,7 +308,8 @@ workflow NFCORE_PROTEINFOLD {
             PREPARE_HELIXFOLD3_DBS.out.helixfold3_pdb_seqres,
             PREPARE_HELIXFOLD3_DBS.out.helixfold3_uniref90,
             PREPARE_HELIXFOLD3_DBS.out.helixfold3_mgnify,
-            PREPARE_HELIXFOLD3_DBS.out.helixfold3_pdb_mmcif,
+            PREPARE_HELIXFOLD3_DBS.out.helixfold3_mmcif_files,
+            PREPARE_HELIXFOLD3_DBS.out.helixfold3_obsolete,
             PREPARE_HELIXFOLD3_DBS.out.helixfold3_init_models,
             PREPARE_HELIXFOLD3_DBS.out.helixfold3_maxit_src
         )

--- a/modules/local/run_helixfold3/main.nf
+++ b/modules/local/run_helixfold3/main.nf
@@ -18,7 +18,8 @@ process RUN_HELIXFOLD3 {
     path ('pdb_seqres/*')
     path ('uniref90/*')
     path ('mgnify/*')
-    path ('pdb_mmcif/*')
+    path ('*')
+    path ('*')
     path ('init_models/*')
     path ('maxit_src')
 
@@ -56,8 +57,8 @@ process RUN_HELIXFOLD3 {
         --uniprot_database_path="./uniprot/uniprot.fasta" \
         --pdb_seqres_database_path="./pdb_seqres/pdb_seqres.txt" \
         --rfam_database_path="./Rfam-14.9_rep_seq.fasta" \
-        --template_mmcif_dir="./pdb_mmcif/mmcif_files" \
-        --obsolete_pdbs_path="./pdb_mmcif/obsolete.dat" \
+        --template_mmcif_dir="./mmcif_files" \
+        --obsolete_pdbs_path="./obsolete.dat" \
         --ccd_preprocessed_path="./ccd_preprocessed_etkdg.pkl.gz" \
         --uniref90_database_path "./uniref90/uniref90.fasta" \
         --mgnify_database_path "./mgnify/mgy_clusters_2018_12.fa" \

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,7 +17,7 @@ params {
 
     // Alphafold2 parameters
     alphafold2_mode             = "standard"
-    max_template_date           = "2020-05-14"
+    max_template_date           = "2038-01-19"
     full_dbs                    = false // true full_dbs, false reduced_dbs
     alphafold2_model_preset     = "monomer" // for AF2 {monomer (default), monomer_casp14, monomer_ptm, multimer}
     alphafold2_db               = null
@@ -105,7 +105,7 @@ params {
     logging_level                = null
     precision                    = null
     infer_times                  = null
-    helixfold3_max_template_date = "2024-08-14"
+    helixfold3_max_template_date = "2038-01-19"
 
     // Helixfold3 links
     helixfold3_uniclust30_link          = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -134,6 +134,7 @@ params {
     helixfold3_uniref90_path            = null
     helixfold3_mgnify_path              = null
     helixfold3_pdb_mmcif_path           = null
+    helixfold3_obsolete_path            = null
     helixfold3_maxit_src_path           = null
 
     // Foldseek params

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -34,7 +34,7 @@
                 },
                 "helixfold3_max_template_date": {
                     "type": "string",
-                    "default": "2024-08-14"
+                    "default": "2038-01-19"
                 }
             }
         },
@@ -216,7 +216,7 @@
             "properties": {
                 "max_template_date": {
                     "type": "string",
-                    "default": "2020-05-14",
+                    "default": "2038-01-19",
                     "description": "Maximum date of the PDB templates used by 'AlphaFold2' mode",
                     "fa_icon": "fas fa-calendar-check"
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -5,155 +5,6 @@
     "description": "Protein 3D structure prediction pipeline",
     "type": "object",
     "$defs": {
-        "helixfold3_options": {
-            "title": "helixfold3 options",
-            "type": "object",
-            "description": "HelixFold3 options",
-            "default": "",
-            "properties": {
-                "helixfold3_db": {
-                    "type": "string"
-                },
-                "model_name": {
-                    "type": "string"
-                },
-                "preset": {
-                    "type": "string"
-                },
-                "init_model": {
-                    "type": "string"
-                },
-                "logging_level": {
-                    "type": "string"
-                },
-                "precision": {
-                    "type": "string"
-                },
-                "infer_times": {
-                    "type": "string"
-                },
-                "helixfold3_max_template_date": {
-                    "type": "string",
-                    "default": "2038-01-19"
-                }
-            }
-        },
-        "helixfold3_dbs_and_parameters_paths_options": {
-            "title": "helixfold3 dbs and parameters paths options",
-            "type": "object",
-            "description": "Parameters used to provide the paths to the DBs and parameters for HelixFold3.",
-            "default": "",
-            "properties": {
-                "helixfold3_init_models_path": {
-                    "type": "string",
-                    "default": "null/HelixFold3-240814.pdparams"
-                },
-                "helixfold3_uniclust30_path": {
-                    "type": "string",
-                    "default": "null/uniclust30/*"
-                },
-                "helixfold3_ccd_preprocessed_path": {
-                    "type": "string",
-                    "default": "null/ccd_preprocessed_etkdg.pkl.gz"
-                },
-                "helixfold3_rfam_path": {
-                    "type": "string",
-                    "default": "null/Rfam-14.9_rep_seq.fasta"
-                },
-                "helixfold3_bfd_path": {
-                    "type": "string",
-                    "default": "null/bfd/*"
-                },
-                "helixfold3_small_bfd_path": {
-                    "type": "string",
-                    "default": "null/small_bfd/*"
-                },
-                "helixfold3_uniprot_path": {
-                    "type": "string",
-                    "default": "null/uniprot/*"
-                },
-                "helixfold3_pdb_seqres_path": {
-                    "type": "string",
-                    "default": "null/pdb_seqres/*"
-                },
-                "helixfold3_uniref90_path": {
-                    "type": "string",
-                    "default": "null/uniref90/*"
-                },
-                "helixfold3_mgnify_path": {
-                    "type": "string",
-                    "default": "null/mgnify/*"
-                },
-                "helixfold3_pdb_mmcif_path": {
-                    "type": "string",
-                    "default": "null/pdb_mmcif/*"
-                },
-                "helixfold3_maxit_src_path": {
-                    "type": "string",
-                    "default": "null/maxit-v11.200-prod-src"
-                }
-            }
-        },
-        "helixfold3_dbs_and_parameters_link_options": {
-            "title": "helixfold3 dbs and parameters link options",
-            "type": "object",
-            "description": "Parameters used to provide the links to the parameters public resources to HelixFold3.",
-            "default": "",
-            "properties": {
-                "helixfold3_init_models_link": {
-                    "type": "string",
-                    "default": "https://paddlehelix.bd.bcebos.com/HelixFold3/params/HelixFold3-params-240814.zip"
-                },
-                "helixfold3_uniclust30_link": {
-                    "type": "string",
-                    "default": "https://storage.googleapis.com/alphafold-databases/casp14_versions/uniclust30_2018_08_hhsuite.tar.gz"
-                },
-                "helixfold3_ccd_preprocessed_link": {
-                    "type": "string",
-                    "default": "https://paddlehelix.bd.bcebos.com/HelixFold3/CCD/ccd_preprocessed_etkdg.pkl.gz"
-                },
-                "helixfold3_rfam_link": {
-                    "type": "string",
-                    "default": "https://paddlehelix.bd.bcebos.com/HelixFold3/MSA/Rfam-14.9_rep_seq.fasta"
-                },
-                "helixfold3_bfd_link": {
-                    "type": "string",
-                    "default": "https://storage.googleapis.com/alphafold-databases/casp14_versions/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz"
-                },
-                "helixfold3_small_bfd_link": {
-                    "type": "string",
-                    "default": "https://storage.googleapis.com/alphafold-databases/reduced_dbs/bfd-first_non_consensus_sequences.fasta.gz"
-                },
-                "helixfold3_pdb_seqres_link": {
-                    "type": "string",
-                    "default": "https://files.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt"
-                },
-                "helixfold3_uniref90_link": {
-                    "type": "string",
-                    "default": "ftp://ftp.uniprot.org/pub/databases/uniprot/uniref/uniref90/uniref90.fasta.gz"
-                },
-                "helixfold3_mgnify_link": {
-                    "type": "string",
-                    "default": "https://storage.googleapis.com/alphafold-databases/casp14_versions/mgy_clusters_2018_12.fa.gz"
-                },
-                "helixfold3_pdb_mmcif_link": {
-                    "type": "string",
-                    "default": "rsync.rcsb.org::ftp_data/structures/divided/mmCIF/"
-                },
-                "helixfold3_uniprot_sprot_link": {
-                    "type": "string",
-                    "default": "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz"
-                },
-                "helixfold3_uniprot_trembl_link": {
-                    "type": "string",
-                    "default": "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_trembl.fasta.gz"
-                },
-                "helixfold3_pdb_obsolete_link": {
-                    "type": "string",
-                    "default": "ftp://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat"
-                }
-            }
-        },
         "input_output_options": {
             "title": "Global options",
             "type": "object",
@@ -381,6 +232,50 @@
                 }
             }
         },
+        "rosettafold_all_atom_options": {
+            "title": "RoseTTAFold All Atom options",
+            "type": "object",
+            "description": "RoseTTAFold All Atom options.",
+            "default": "",
+            "properties": {
+                "rosettafold_all_atom_db": {
+                    "type": "string"
+                }
+            }
+        },
+        "helixfold3_options": {
+            "title": "HelixFold3 options",
+            "type": "object",
+            "description": "HelixFold3 options",
+            "default": "",
+            "properties": {
+                "helixfold3_db": {
+                    "type": "string"
+                },
+                "model_name": {
+                    "type": "string"
+                },
+                "preset": {
+                    "type": "string"
+                },
+                "init_model": {
+                    "type": "string"
+                },
+                "logging_level": {
+                    "type": "string"
+                },
+                "precision": {
+                    "type": "string"
+                },
+                "infer_times": {
+                    "type": "string"
+                },
+                "helixfold3_max_template_date": {
+                    "type": "string",
+                    "default": "2038-01-19"
+                }
+            }
+        },
         "process_skipping_options": {
             "title": "Process skipping options",
             "type": "object",
@@ -527,8 +422,8 @@
                 }
             }
         },
-        "alphafold2_dbs_and_parameters_path_options": {
-            "title": "Alphafold2 DBs and parameters links options",
+        "alphafold2_dbs_and_parameters_paths_options": {
+            "title": "Alphafold2 DBs and parameters paths options",
             "type": "object",
             "fa_icon": "fas fa-database",
             "description": "Parameters used to provide the paths to the DBs and parameters for Alphafold2.",
@@ -626,10 +521,10 @@
                 }
             }
         },
-        "colabfold_dbs_and_parameters_path_options": {
-            "title": "Colabfold DBs and parameters links options",
+        "colabfold_dbs_and_parameters_paths_options": {
+            "title": "Colabfold DBs and parameters paths options",
             "type": "object",
-            "description": "Parameters used to provide the links to the DBs and parameters public resources to Colabfold.",
+            "description": "Parameters used to provide the paths to the DBs and parameters public resources to Colabfold.",
             "fa_icon": "fas fa-database",
             "properties": {
                 "colabfold_db_path": {
@@ -682,10 +577,10 @@
                 }
             }
         },
-        "esmfold_parameters_path_options": {
-            "title": "Esmfold parameters links options",
+        "esmfold_parameters_paths_options": {
+            "title": "Esmfold parameters paths options",
             "type": "object",
-            "description": "Parameters used to provide the links to the parameters public resources to Esmfold.",
+            "description": "Parameters used to provide the paths to the parameters public resources to Esmfold.",
             "fa_icon": "fas fa-database",
             "properties": {
                 "esmfold_params_path": {
@@ -801,17 +696,6 @@
                 }
             }
         },
-        "rosettafold_all_atom_options": {
-            "title": "RoseTTAFold All Atom options",
-            "type": "object",
-            "description": "RoseTTAFold All Atom options.",
-            "default": "",
-            "properties": {
-                "rosettafold_all_atom_db": {
-                    "type": "string"
-                }
-            }
-        },
         "rosettafold_all_atom_dbs_and_parameters_links_options": {
             "title": "RoseTTAFold All Atom DBs and parameters links options",
             "type": "object",
@@ -859,18 +743,132 @@
                     "default": "null/RFAA_paper_weights.pt"
                 }
             }
+        },
+        "helixfold3_dbs_and_parameters_paths_options": {
+            "title": "helixfold3 dbs and parameters paths options",
+            "type": "object",
+            "description": "Parameters used to provide the paths to the DBs and parameters for HelixFold3.",
+            "default": "",
+            "properties": {
+                "helixfold3_init_models_path": {
+                    "type": "string",
+                    "default": "null/HelixFold3-240814.pdparams"
+                },
+                "helixfold3_uniclust30_path": {
+                    "type": "string",
+                    "default": "null/uniclust30/*"
+                },
+                "helixfold3_ccd_preprocessed_path": {
+                    "type": "string",
+                    "default": "null/ccd_preprocessed_etkdg.pkl.gz"
+                },
+                "helixfold3_rfam_path": {
+                    "type": "string",
+                    "default": "null/Rfam-14.9_rep_seq.fasta"
+                },
+                "helixfold3_bfd_path": {
+                    "type": "string",
+                    "default": "null/bfd/*"
+                },
+                "helixfold3_small_bfd_path": {
+                    "type": "string",
+                    "default": "null/small_bfd/*"
+                },
+                "helixfold3_uniprot_path": {
+                    "type": "string",
+                    "default": "null/uniprot/*"
+                },
+                "helixfold3_pdb_seqres_path": {
+                    "type": "string",
+                    "default": "null/pdb_seqres/*"
+                },
+                "helixfold3_uniref90_path": {
+                    "type": "string",
+                    "default": "null/uniref90/*"
+                },
+                "helixfold3_mgnify_path": {
+                    "type": "string",
+                    "default": "null/mgnify/*"
+                },
+                "helixfold3_pdb_mmcif_path": {
+                    "type": "string",
+                    "default": "null/pdb_mmcif/mmcif_files"
+                },
+                "helixfold3_maxit_src_path": {
+                    "type": "string",
+                    "default": "null/maxit-v11.200-prod-src"
+                },
+                "helixfold3_obsolete_path": {
+                    "type": "string",
+                    "default": "null/pdb_mmcif/obsolete.dat"
+                }
+            }
+        },
+        "helixfold3_dbs_and_parameters_link_options": {
+            "title": "helixfold3 dbs and parameters link options",
+            "type": "object",
+            "description": "Parameters used to provide the links to the parameters public resources to HelixFold3.",
+            "default": "",
+            "properties": {
+                "helixfold3_init_models_link": {
+                    "type": "string",
+                    "default": "https://paddlehelix.bd.bcebos.com/HelixFold3/params/HelixFold3-params-240814.zip"
+                },
+                "helixfold3_uniclust30_link": {
+                    "type": "string",
+                    "default": "https://storage.googleapis.com/alphafold-databases/casp14_versions/uniclust30_2018_08_hhsuite.tar.gz"
+                },
+                "helixfold3_ccd_preprocessed_link": {
+                    "type": "string",
+                    "default": "https://paddlehelix.bd.bcebos.com/HelixFold3/CCD/ccd_preprocessed_etkdg.pkl.gz"
+                },
+                "helixfold3_rfam_link": {
+                    "type": "string",
+                    "default": "https://paddlehelix.bd.bcebos.com/HelixFold3/MSA/Rfam-14.9_rep_seq.fasta"
+                },
+                "helixfold3_bfd_link": {
+                    "type": "string",
+                    "default": "https://storage.googleapis.com/alphafold-databases/casp14_versions/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz"
+                },
+                "helixfold3_small_bfd_link": {
+                    "type": "string",
+                    "default": "https://storage.googleapis.com/alphafold-databases/reduced_dbs/bfd-first_non_consensus_sequences.fasta.gz"
+                },
+                "helixfold3_pdb_seqres_link": {
+                    "type": "string",
+                    "default": "https://files.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt"
+                },
+                "helixfold3_uniref90_link": {
+                    "type": "string",
+                    "default": "ftp://ftp.uniprot.org/pub/databases/uniprot/uniref/uniref90/uniref90.fasta.gz"
+                },
+                "helixfold3_mgnify_link": {
+                    "type": "string",
+                    "default": "https://storage.googleapis.com/alphafold-databases/casp14_versions/mgy_clusters_2018_12.fa.gz"
+                },
+                "helixfold3_pdb_mmcif_link": {
+                    "type": "string",
+                    "default": "rsync.rcsb.org::ftp_data/structures/divided/mmCIF/"
+                },
+                "helixfold3_uniprot_sprot_link": {
+                    "type": "string",
+                    "default": "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz"
+                },
+                "helixfold3_uniprot_trembl_link": {
+                    "type": "string",
+                    "default": "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_trembl.fasta.gz"
+                },
+                "helixfold3_pdb_obsolete_link": {
+                    "type": "string"
+                },
+                "helixfold3_obsolete_link": {
+                    "type": "string",
+                    "default": "ftp://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat"
+                }
+            }
         }
     },
     "allOf": [
-        {
-            "$ref": "#/$defs/helixfold3_options"
-        },
-        {
-            "$ref": "#/$defs/helixfold3_dbs_and_parameters_paths_options"
-        },
-        {
-            "$ref": "#/$defs/helixfold3_dbs_and_parameters_link_options"
-        },
         {
             "$ref": "#/$defs/input_output_options"
         },
@@ -887,6 +885,12 @@
             "$ref": "#/$defs/foldseek_options"
         },
         {
+            "$ref": "#/$defs/rosettafold_all_atom_options"
+        },
+        {
+            "$ref": "#/$defs/helixfold3_options"
+        },
+        {
             "$ref": "#/$defs/process_skipping_options"
         },
         {
@@ -896,31 +900,34 @@
             "$ref": "#/$defs/alphafold2_dbs_and_parameters_link_options"
         },
         {
-            "$ref": "#/$defs/alphafold2_dbs_and_parameters_path_options"
+            "$ref": "#/$defs/alphafold2_dbs_and_parameters_paths_options"
         },
         {
             "$ref": "#/$defs/colabfold_dbs_and_parameters_link_options"
         },
         {
-            "$ref": "#/$defs/colabfold_dbs_and_parameters_path_options"
+            "$ref": "#/$defs/colabfold_dbs_and_parameters_paths_options"
         },
         {
             "$ref": "#/$defs/esmfold_parameters_link_options"
         },
         {
-            "$ref": "#/$defs/esmfold_parameters_path_options"
+            "$ref": "#/$defs/esmfold_parameters_paths_options"
         },
         {
             "$ref": "#/$defs/generic_options"
-        },
-        {
-            "$ref": "#/$defs/rosettafold_all_atom_options"
         },
         {
             "$ref": "#/$defs/rosettafold_all_atom_dbs_and_parameters_links_options"
         },
         {
             "$ref": "#/$defs/rosettafold_all_atom_dbs_and_parameters_paths_options"
+        },
+        {
+            "$ref": "#/$defs/helixfold3_dbs_and_parameters_paths_options"
+        },
+        {
+            "$ref": "#/$defs/helixfold3_dbs_and_parameters_link_options"
         }
     ]
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -887,7 +887,7 @@
                 },
                 "helixfold3_obsolete_link": {
                     "type": "string",
-                    "default": "ftp://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat"
+                    "default": "https://files.rcsb.org/pub/pdb/data/status/obsolete.dat"
                 }
             }
         }

--- a/subworkflows/local/prepare_helixfold3_dbs.nf
+++ b/subworkflows/local/prepare_helixfold3_dbs.nf
@@ -10,6 +10,7 @@ include {
     ARIA2_UNCOMPRESS as ARIA2_SMALL_BFD
     ARIA2_UNCOMPRESS as ARIA2_UNIPROT_SPROT
     ARIA2_UNCOMPRESS as ARIA2_UNIPROT_TREMBL
+    ARIA2_UNCOMPRESS as ARIA2_OBSOLETE
     ARIA2_UNCOMPRESS as ARIA2_UNIREF90
     ARIA2_UNCOMPRESS as ARIA2_MGNIFY
     ARIA2_UNCOMPRESS as ARIA2_INIT_MODELS
@@ -35,7 +36,7 @@ workflow PREPARE_HELIXFOLD3_DBS {
     helixfold3_uniref90_link
     helixfold3_mgnify_link
     helixfold3_pdb_mmcif_link
-    helixfold3_pdb_obsolete_link
+    helixfold3_obsolete_link
     helixfold3_uniclust30_path
     helixfold3_ccd_preprocessed_path
     helixfold3_rfam_path
@@ -47,6 +48,7 @@ workflow PREPARE_HELIXFOLD3_DBS {
     helixfold3_uniref90_path
     helixfold3_mgnify_path
     helixfold3_pdb_mmcif_path
+    helixfold3_obsolete_path
     helixfold3_maxit_src_path
 
     main:
@@ -63,9 +65,8 @@ workflow PREPARE_HELIXFOLD3_DBS {
         ch_helixfold3_pdb_seqres        = Channel.value(file(helixfold3_pdb_seqres_path))
         ch_helixfold3_uniref90          = Channel.value(file(helixfold3_uniref90_path))
         ch_helixfold3_mgnify            = Channel.value(file(helixfold3_mgnify_path))
-        ch_mmcif_files                  = file(helixfold3_pdb_mmcif_path, type: 'dir')
-        ch_mmcif_obsolete               = file(helixfold3_pdb_mmcif_path, type: 'file')
-        ch_helixfold3_pdb_mmcif         = Channel.value(ch_mmcif_files + ch_mmcif_obsolete)
+        ch_helixfold3_mmcif_files       = Channel.value(file(helixfold3_pdb_mmcif_path))
+        ch_helixfold3_obsolete          = Channel.value(file(helixfold3_obsolete_path))
         ch_helixfold3_init_models       = Channel.value(file(helixfold3_init_models_path))
     }
     else {
@@ -97,13 +98,21 @@ workflow PREPARE_HELIXFOLD3_DBS {
         ch_helixfold3_mgnify = ARIA2_MGNIFY.out.db
         ch_versions = ch_versions.mix(ARIA2_MGNIFY.out.versions)
 
-        DOWNLOAD_PDBMMCIF(helixfold3_pdb_mmcif_link, helixfold3_pdb_obsolete_link)
-        ch_helixfold3_pdb_mmcif = DOWNLOAD_PDBMMCIF.out.ch_db
-        ch_versions = ch_versions.mix(DOWNLOAD_PDBMMCIF.out.versions)
+        DOWNLOAD_PDBMMCIF(
+            helixfold3_pdb_mmcif_link
+            )
+        ch_helixfold3_mmcif_files = DOWNLOAD_PDBMMCIF.out.ch_db
+        ch_versions               = ch_versions.mix(DOWNLOAD_PDBMMCIF.out.versions)
+
+        ARIA2_OBSOLETE(
+            helixfold3_obsolete_link
+        )
+        ch_helixfold3_obsolete = ARIA2_OBSOLETE.out.db
+        ch_versions            = ch_versions.mix(ARIA2_OBSOLETE.out.versions)
 
         ARIA2_INIT_MODELS(helixfold3_init_models_link)
         ch_helixfold3_init_models = ARIA2_INIT_MODELS.out.db
-        ch_versions = ch_versions.mix(ARIA2_INIT_MODELS.out.versions)
+        ch_versions               = ch_versions.mix(ARIA2_INIT_MODELS.out.versions)
 
         ARIA2_PDB_SEQRES (
             [
@@ -141,7 +150,8 @@ workflow PREPARE_HELIXFOLD3_DBS {
     helixfold3_pdb_seqres       = ch_helixfold3_pdb_seqres
     helixfold3_uniref90         = ch_helixfold3_uniref90
     helixfold3_mgnify           = ch_helixfold3_mgnify
-    helixfold3_pdb_mmcif        = ch_helixfold3_pdb_mmcif
+    helixfold3_mmcif_files      = ch_helixfold3_mmcif_files
+    helixfold3_obsolete         = ch_helixfold3_obsolete
     helixfold3_init_models      = ch_helixfold3_init_models
     helixfold3_maxit_src        = ch_helixfold3_maxit_src
     versions                    = ch_versions

--- a/workflows/helixfold3.nf
+++ b/workflows/helixfold3.nf
@@ -35,7 +35,8 @@ workflow HELIXFOLD3 {
     ch_helixfold3_pdb_seqres
     ch_helixfold3_uniref90
     ch_helixfold3_mgnify
-    ch_helixfold3_pdb_mmcif
+    ch_helixfold3_mmcif_files
+    ch_helixfold3_obsolete
     ch_helixfold3_init_models
     ch_helixfold3_maxit_src
 
@@ -60,7 +61,8 @@ workflow HELIXFOLD3 {
         ch_helixfold3_pdb_seqres,
         ch_helixfold3_uniref90,
         ch_helixfold3_mgnify,
-        ch_helixfold3_pdb_mmcif,
+        ch_helixfold3_mmcif_files,
+        ch_helixfold3_obsolete,
         ch_helixfold3_init_models,
         ch_helixfold3_maxit_src
     )


### PR DESCRIPTION
Fixes the error from https://github.com/nf-core/proteinfold/issues/299 

- Handling of `mmcif_files` and `obsolete.dat` has been modified to match AF2
- Removes superfluous helixfold3_ from `--max_template_date` in `modules_helixfold3.config`
- `max_template_date` values in `nextflow.config` updated to ensure runs default to using the latest available

<!--
# nf-core/proteinfold pull request

Many thanks for contributing to nf-core/proteinfold!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] `CHANGELOG.md` is updated.
