### PR TITLE
Stop RFAA and HF3 symlinking scripts into workdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#273](https://github.com/nf-core/proteinfold/issues/273)] - Fixes comparison report to correctly label msa coverage plots with corresponding method label.
 - [[#290](https://github.com/nf-core/proteinfold/issues/290)] - Update Alphafold2 split images to make them compatible Hopper gpus.
 - [[PR #302](https://github.com/nf-core/proteinfold/pull/302)] - Fix HF3 dbs and max_template_date.
+- [[#305](https://github.com/nf-core/proteinfold/pull/305)] - Stop RFAA and HF3 symlinking scripts into workdir.
 
 ### Parameters
 

--- a/modules/local/run_helixfold3/main.nf
+++ b/modules/local/run_helixfold3/main.nf
@@ -41,9 +41,7 @@ process RUN_HELIXFOLD3 {
     }
     def args = task.ext.args ?: ''
     """
-    ln -s /app/helixfold3/* .
-
-    mamba run --name helixfold python3.9 inference.py \
+    mamba run --name helixfold python3.9 /app/helixfold3/inference.py \
         --maxit_binary "./maxit_src/bin/maxit" \
         --jackhmmer_binary_path "jackhmmer" \
         --hhblits_binary_path "hhblits" \

--- a/modules/local/run_rosettafold_all_atom/main.nf
+++ b/modules/local/run_rosettafold_all_atom/main.nf
@@ -31,9 +31,7 @@ process RUN_ROSETTAFOLD_ALL_ATOM {
     def VERSION = '1.2.0dev' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
     """
-    ln -s /app/RoseTTAFold-All-Atom/* .
-
-    mamba run --name RFAA python -m rf2aa.run_inference \
+    mamba run --name RFAA python /app/RoseTTAFold-All-Atom/rf2aa/run_inference.py \
     --config-dir /app/RoseTTAFold-All-Atom/rf2aa/config/inference \
     --config-name "${fasta}" \
     $args


### PR DESCRIPTION
- Uses direct path instead of symlinking
    _- An alternative would be to add a `chmod +x` line in the Dockerfile so that they can be run directly from PATH_


<!--
# nf-core/proteinfold pull request

Many thanks for contributing to nf-core/proteinfold!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.