### PR TITLE
Fix extract metrics for broken modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #305](https://github.com/nf-core/proteinfold/pull/305)] - Stop RFAA and HF3 symlinking scripts into workdir.
 - [[PR #306](https://github.com/nf-core/proteinfold/pull/306)] - extract_output.py -> extract_metrics.py so pLDDT, MSA, PAE emitted as raw data .tsv files
 - [[PR #307](https://github.com/nf-core/proteinfold/pull/307)] - Update Boltz-1 boilerplate and formatting.
+- [[PR #314](https://github.com/nf-core/proteinfold/pull/314)] - Fix extract metrics for broken modules.
 
 ### Parameters
 

--- a/bin/generate_report.py
+++ b/bin/generate_report.py
@@ -286,8 +286,12 @@ def pdb_to_lddt(struct_files, generate_tsv):
                 res_atom_count +=1
                 res_pLDDT_tot += atom.get_bfactor()
 
-            plddt_values.append(res_pLDDT_tot/res_atom_count) #residue-level mean for ESMfold atom-level pLDDT
+            # Residue-level mean for ESMfold atom-level pLDDT
+            res_pLDDT_ave = res_pLDDT_tot/res_atom_count
 
+            if res_pLDDT_ave < 1.0:
+                res_pLDDT_ave *= 100
+            plddt_values.append(res_pLDDT_ave)
 
         # Calculate the average PLDDT value for the current file
         if plddt_values:

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -1,10 +1,60 @@
-from Bio import PDB
+import importlib.util
 import numpy as np
+bio_is_installed = importlib.util.find_spec("Bio") is not None
 
-def plddt_from_struct_b_factor(struct_file):
+def _convert_plddt_to_100(res_plddt):
+    if (res_plddt < 1):  # Converting to a [0,100] range
+        res_plddt *= 100
+    return res_plddt
+
+
+def plddt_from_struct_b_factor_adhoc(struct_file):
+    """
+    Uses ad hoc PDB parser to extract residue pLDDT values from the b-factor column. Iterates over PDB objects rather than processes raw file
+    """
+    #NOTE: this is a temporary hack which is not robust as a general parser.
+    #Should be temporary - need to check with non-protein entities
+    if not str(struct_file).endswith(".pdb"):
+        raise ValueError(f"{struct_file} must be a PDB file!")
+
+    res_plddts = []
+    resid_prev = -1
+    atom_plddt_list = []
+
+    with open(struct_file) as f:
+        for line in f:
+            if not line.startswith('ATOM'): continue
+            resid = int(line[23:26].strip())
+            if resid == resid_prev:
+                atom_plddt_list.append(float(line[61:66].strip()))
+            else:
+                if resid_prev == -1:
+                    resid_prev = resid
+                    continue
+                res_plddt = sum(atom_plddt_list)/len(atom_plddt_list)
+                res_plddt = _convert_plddt_to_100(res_plddt)
+                res_plddts.append(res_plddt)
+                resid_prev = resid
+
+                # Reset atom tracking
+                atom_plddt_list = []
+                atom_plddt_list.append(float(line[61:66].strip()))
+
+        res_plddt = sum(atom_plddt_list)/len(atom_plddt_list)
+        res_plddt = _convert_plddt_to_100(res_plddt)
+        res_plddts.append(res_plddt)
+
+    res_plddts = np.array(res_plddts)
+    res_plddts = np.round(res_plddts, 2)
+
+    return res_plddts
+
+
+def plddt_from_struct_b_factor_biopython(struct_file):
     """
     Uses the BioPython PDB package to extract residue pLDDT values from the b-factor column. Iterates over PDB objects rather than processes raw file
     """
+    from Bio import PDB
     if str(struct_file).endswith(".pdb"):
         parser = PDB.PDBParser(QUIET=True)
         structure = parser.get_structure(id=id, file=struct_file)
@@ -12,16 +62,16 @@ def plddt_from_struct_b_factor(struct_file):
         parser = PDB.MMCIFParser(QUIET=True)
         structure = parser.get_structure(structure_id=id, filename=struct_file)
     else:
-        print(f"{struct_file} is neither a PDB or mmCIF file!")
+        raise ValueError(f"{struct_file} is neither a PDB or mmCIF file!")
 
-    res_list = []
+#    res_list = []
     res_plddts = []
-    plddt_tot = 0
+#    plddt_tot = 0
 
     for model in structure:
         for chain in model:
             chain_res_list = chain.get_unpacked_list()
-            res_list.extend(chain_res_list)
+#            res_list.extend(chain_res_list)
             for residue in chain:
                 atom_list = residue.get_unpacked_list()
                 atom_plddt_tot = 0
@@ -33,11 +83,17 @@ def plddt_from_struct_b_factor(struct_file):
 
                 if (res_plddt < 1):  # RFAA the multiplication of mean isn't failing. Anyway covering to a [0,100] range for any structure file1
                     res_plddt *= 100
+                res_plddt = _convert_plddt_to_100(res_plddt)
 
                 res_plddts.append(res_plddt)
-                plddt_tot += res_plddt
+#                plddt_tot += res_plddt
 
     res_plddts = np.array(res_plddts)
     res_plddts = np.round(res_plddts, 2)
 
     return res_plddts
+
+if bio_is_installed:
+    plddt_from_struct_b_factor = plddt_from_struct_b_factor_biopython
+else:
+    plddt_from_struct_b_factor = plddt_from_struct_b_factor_adhoc

--- a/modules/local/colabfold_batch/main.nf
+++ b/modules/local/colabfold_batch/main.nf
@@ -14,7 +14,7 @@ process COLABFOLD_BATCH {
 
     output:
     tuple val(meta), path ("${meta.id}_colabfold.pdb"), emit: top_ranked_pdb
-    tuple val(meta), path ("*_relaxed_rank_*.pdb")    , emit: pdb
+    tuple val(meta), path ("*relaxed_rank_*.pdb")     , emit: pdb
     tuple val(meta), path ("*_coverage.png")          , emit: msa
     tuple val(meta), path ("*_mqc.png")               , emit: multiqc
     path "versions.yml"                               , emit: versions
@@ -39,9 +39,14 @@ process COLABFOLD_BATCH {
         --model-type ${colabfold_model_preset} \\
         ${fasta} \\
         \$PWD
-    for i in `find *_relaxed_rank_001*.pdb`; do cp \$i `echo \$i | sed "s|_relaxed_rank_|\t|g" | cut -f1`"_colabfold.pdb"; done
     for i in `find *.png -maxdepth 0`; do cp \$i \${i%'.png'}_mqc.png; done
-    cp *_relaxed_rank_001*.pdb ${meta.id}_colabfold.pdb
+    if [ ! -e `find *_relaxed_rank_001_*.pdb` ]; then
+        #for i in `find *_relaxed_rank_001*.pdb`; do cp \$i `echo \$i | sed "s|_relaxed_rank_|\t|g" | cut -f1`"_colabfold.pdb"; done
+        cp *_relaxed_rank_001*.pdb ${meta.id}_colabfold.pdb
+    else
+        #for i in `find *_unrelaxed_rank_001*.pdb`; do cp \$i `echo \$i | sed "s|_unrelaxed_rank_|\t|g" | cut -f1`"_colabfold.pdb"; done
+        cp *_unrelaxed_rank_001*.pdb ${meta.id}_colabfold.pdb
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/run_esmfold/main.nf
+++ b/modules/local/run_esmfold/main.nf
@@ -42,6 +42,8 @@ process RUN_ESMFOLD {
         $args
 
     mv  *.pdb ${meta.id}_esmfold.pdb
+    extract_metrics.py --name ${meta.id} \\
+        --structs ${meta.id}_esmfold.pdb
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/run_helixfold3/main.nf
+++ b/modules/local/run_helixfold3/main.nf
@@ -43,37 +43,42 @@ process RUN_HELIXFOLD3 {
     }
     def args = task.ext.args ?: ''
     """
-    mamba run --name helixfold python3.9 /app/helixfold3/inference.py \
-        --maxit_binary "./maxit_src/bin/maxit" \
-        --jackhmmer_binary_path "jackhmmer" \
-        --hhblits_binary_path "hhblits" \
-        --hhsearch_binary_path "hhsearch" \
-        --kalign_binary_path "kalign" \
-        --hmmsearch_binary_path "hmmsearch" \
-        --hmmbuild_binary_path "hmmbuild" \
-        --bfd_database_path="./bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt" \
-        --small_bfd_database_path="./small_bfd/bfd-first_non_consensus_sequences.fasta" \
-        --uniclust30_database_path="./uniclust30/uniclust30_2018_08" \
-        --uniprot_database_path="./uniprot/uniprot.fasta" \
-        --pdb_seqres_database_path="./pdb_seqres/pdb_seqres.txt" \
-        --rfam_database_path="./Rfam-14.9_rep_seq.fasta" \
-        --template_mmcif_dir="./mmcif_files" \
-        --obsolete_pdbs_path="./obsolete.dat" \
-        --ccd_preprocessed_path="./ccd_preprocessed_etkdg.pkl.gz" \
-        --uniref90_database_path "./uniref90/uniref90.fasta" \
-        --mgnify_database_path "./mgnify/mgy_clusters_2018_12.fa" \
-        --input_json="${fasta}" \
-        --output_dir="\$PWD" \
-        $args
+    mamba run --name helixfold python3.9 /app/helixfold3/inference.py \\
+        --maxit_binary "./maxit_src/bin/maxit" \\
+        --jackhmmer_binary_path "jackhmmer" \\
+        --hhblits_binary_path "hhblits" \\
+        --hhsearch_binary_path "hhsearch" \\
+        --kalign_binary_path "kalign" \\
+        --hmmsearch_binary_path "hmmsearch" \\
+        --hmmbuild_binary_path "hmmbuild" \\
+        --nhmmer_binary_path "nhmmer" \\
+        --bfd_database_path="./bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt" \\
+        --small_bfd_database_path="./small_bfd/bfd-first_non_consensus_sequences.fasta" \\
+        --uniclust30_database_path="./uniclust30/uniclust30_2018_08" \\
+        --uniprot_database_path="./uniprot/uniprot.fasta" \\
+        --pdb_seqres_database_path="./pdb_seqres/pdb_seqres.txt" \\
+        --rfam_database_path="./Rfam-14.9_rep_seq.fasta" \\
+        --template_mmcif_dir="./mmcif_files" \\
+        --obsolete_pdbs_path="./obsolete.dat" \\
+        --ccd_preprocessed_path="./ccd_preprocessed_etkdg.pkl.gz" \\
+        --uniref90_database_path "./uniref90/uniref90.fasta" \\
+        --mgnify_database_path "./mgnify/mgy_clusters_2018_12.fa" \\
+        --input_json="${fasta}" \\
+        --output_dir="\$PWD" $args
 
     cp "${fasta.baseName}/${fasta.baseName}-rank1/predicted_structure.pdb" "./${meta.id}_helixfold3.pdb"
     cp "${fasta.baseName}/${fasta.baseName}-rank1/predicted_structure.cif" "./${meta.id}_helixfold3.cif"
 
 
-    extract_output.py --name ${meta.id} \\
-        --structs "${fasta.baseName}/${fasta.baseName}-rank*/predicted_structure.pdb" \\
+    mamba run --name helixfold extract_metrics.py --name ${meta.id} \\
+        --structs ${fasta.baseName}/${fasta.baseName}-rank*/predicted_structure.pdb \\
         --pkls "${fasta.baseName}/final_features.pkl" \\
-        --jsons "${fasta.baseName}-rank*/all_results.json"
+        --jsons ${fasta.baseName}/${fasta.baseName}-rank*/all_results.json
+
+    [ ! -d ${meta.id} ] && mkdir ${meta.id}
+    for i in 1 2 3 4 5
+        do cp "${fasta.baseName}/${fasta.baseName}-rank\$i/predicted_structure.pdb" "${meta.id}/ranked_\$i.pdb"
+    done
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -93,6 +98,7 @@ process RUN_HELIXFOLD3 {
     touch "${meta.id}/ranked_2.pdb"
     touch "${meta.id}/ranked_3.pdb"
     touch "${meta.id}/ranked_4.pdb"
+    touch "${meta.id}/ranked_5.pdb"
 
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/run_rosettafold_all_atom/main.nf
+++ b/modules/local/run_rosettafold_all_atom/main.nf
@@ -20,7 +20,7 @@ process RUN_ROSETTAFOLD_ALL_ATOM {
     tuple val(meta), path ("${meta.id}_plddt.tsv")               , emit: multiqc
     tuple val(meta), path ("${meta.id}_msa.tsv")                 , emit: msa
     // I think there should always be PAE from the .pt PyTorch model. extract_metrics.py has condition import torch to handle this
-    tuple val(meta), path ("${meta.id}_*_pae.tsv")               , emit: paes
+    tuple val(meta), path ("${meta.id}_pae.tsv")                 , emit: paes
     path "versions.yml"                                          , emit: versions
 
     when:
@@ -35,15 +35,19 @@ process RUN_ROSETTAFOLD_ALL_ATOM {
     }
     def args = task.ext.args ?: ''
     """
-    mamba run --name RFAA python /app/RoseTTAFold-All-Atom/rf2aa/run_inference.py \
-    --config-dir /app/RoseTTAFold-All-Atom/rf2aa/config/inference \
-    --config-name "${yaml}" \
-    $args
+    mamba run --name RFAA python /app/RoseTTAFold-All-Atom/rf2aa/run_inference.py \\
+        --config-dir /app/RoseTTAFold-All-Atom/rf2aa/config/inference \\
+        --config-name "${yaml}" $args
+
+    # Temporary hack - maybe better to sanitize YAML - job_name -> meta.id?
+    yaml_name="\$(grep ^job_name ${yaml} | awk '{print \$2}' |  sed 's/\"//g')"
+
+    cp "\$yaml_name".pdb "${meta.id}"_rosettafold_all_atom.pdb
 
     mamba run --name RFAA extract_metrics.py --name ${meta.id} \\
-        --structs "${yaml.baseName}_rosettafold_all_atom.pdb" \\
-        --a3ms "${yaml.baseName}/A/t000_.msa0.a3m" \\
-        --pts ${yaml.baseName}_aux.pt
+        --structs "${meta.id}_rosettafold_all_atom.pdb" \\
+        --a3ms "\$yaml_name"/A/t000_.msa0.a3m \\
+        --pts "\$yaml_name"_aux.pt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -58,7 +62,7 @@ process RUN_ROSETTAFOLD_ALL_ATOM {
     touch "${meta.id}_aux.pt"
     touch "${meta.id}_plddt.tsv"
     touch "${meta.id}_msa.tsv"
-    touch "${meta.id}_0_pae.tsv"
+    touch "${meta.id}_pae.tsv"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/subworkflows/local/post_processing.nf
+++ b/subworkflows/local/post_processing.nf
@@ -78,8 +78,6 @@ workflow POST_PROCESSING {
                 }
                 .set { ch_comparison_report_input }
 
-            ch_comparison_report_input.view()
-
             COMPARE_STRUCTURES(
                 ch_comparison_report_input
                     .map {


### PR DESCRIPTION
- Fixed HF3
  - Fixed metric parsing
  - Restored support for non-fasta input where name is different to meta.id
  - Added path to nhmmer binary required for RNA
- Fixed RFAA
  - Fixed metric parsing
  - Restored support for non-fasta input where name is different to meta.id
- Fixed colabfold_batch for unrelaxed case (related to #244)
- Added temporary non-biopython PDBparser for containers without biopython installed
- Added extract_metrics to esmfold to populate required channels

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] `CHANGELOG.md` is updated.
