### PR TITLE
Adds process_gpu label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #306](https://github.com/nf-core/proteinfold/pull/306)] - extract_output.py -> extract_metrics.py so pLDDT, MSA, PAE emitted as raw data .tsv files
 - [[PR #307](https://github.com/nf-core/proteinfold/pull/307)] - Update Boltz-1 boilerplate and formatting.
 - [[PR #314](https://github.com/nf-core/proteinfold/pull/314)] - Fix extract metrics for broken modules.
+- [[PR #316](https://github.com/nf-core/proteinfold/pull/316)] - Add process_gpu label to modules which use GPU.
 
 ### Parameters
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -52,6 +52,9 @@ process {
     withLabel:process_high_memory {
         memory = { 200.GB * task.attempt }
     }
+    withLabled:process_gpu {
+        accelerator = 1
+    }
     withLabel:error_ignore {
         errorStrategy = 'ignore'
     }

--- a/modules/local/colabfold_batch/main.nf
+++ b/modules/local/colabfold_batch/main.nf
@@ -1,6 +1,7 @@
 process COLABFOLD_BATCH {
     tag "$meta.id"
     label 'process_medium'
+    label 'process_gpu'
 
     container "nf-core/proteinfold_colabfold:dev"
 

--- a/modules/local/run_alphafold2/main.nf
+++ b/modules/local/run_alphafold2/main.nf
@@ -4,6 +4,7 @@
 process RUN_ALPHAFOLD2 {
     tag "$meta.id"
     label 'process_medium'
+    label 'process_gpu'
 
     container "nf-core/proteinfold_alphafold2_standard:dev"
 

--- a/modules/local/run_alphafold2_pred/main.nf
+++ b/modules/local/run_alphafold2_pred/main.nf
@@ -4,6 +4,7 @@
 process RUN_ALPHAFOLD2_PRED {
     tag   "$meta.id"
     label 'process_medium'
+    label 'process_gpu'
 
     container "nf-core/proteinfold_alphafold2_pred:dev"
 

--- a/modules/local/run_esmfold/main.nf
+++ b/modules/local/run_esmfold/main.nf
@@ -1,6 +1,7 @@
 process RUN_ESMFOLD {
     tag "$meta.id"
     label 'process_medium'
+    label 'process_gpu'
 
     container "nf-core/proteinfold_esmfold:dev"
 

--- a/modules/local/run_helixfold3/main.nf
+++ b/modules/local/run_helixfold3/main.nf
@@ -4,6 +4,7 @@
 process RUN_HELIXFOLD3 {
     tag "$meta.id"
     label 'process_medium'
+    label 'process_gpu'
 
     container "nf-core/proteinfold_helixfold3:dev"
 

--- a/modules/local/run_rosettafold_all_atom/main.nf
+++ b/modules/local/run_rosettafold_all_atom/main.nf
@@ -4,6 +4,7 @@
 process RUN_ROSETTAFOLD_ALL_ATOM {
     tag "$meta.id"
     label 'process_medium'
+    label 'process_gpu'
 
     container "nf-core/proteinfold_rosettafold_all_atom:dev"
 


### PR DESCRIPTION
Adds `label: process_gpu` to modules which use GPU. There is not yet a standardised label for indicating GPU processes under nf-core. This seems like a sensible option and I have opened a PR to have it added to our config https://github.com/nf-core/configs/pull/907
<!--
# nf-core/proteinfold pull request

Many thanks for contributing to nf-core/proteinfold!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
