### PR TITLE
Update boltz workflow to accept YAML as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #315](https://github.com/nf-core/proteinfold/pull/315)] - Add global db flag.
 - [[#263](https://github.com/nf-core/proteinfold/issues/263)] - Removed broken colabfold options (`auto` and `alphafold2`)
 - [[PR #316](https://github.com/nf-core/proteinfold/pull/316)] - Add process_gpu label to modules which use GPU.
+- [[PR #319](https://github.com/nf-core/proteinfold/pull/319)] - Update boltz workflow to accept YAML as input.
 
 ### Parameters
 

--- a/workflows/boltz.nf
+++ b/workflows/boltz.nf
@@ -119,9 +119,9 @@ workflow BOLTZ {
         )
 
     ch_input_by_ext.yaml
-    .map { [it[0], it[1], []] }  // already in YAML
-    .mix(BOLTZ_FASTA.out.formatted_fasta) // newly converted from FASTA
-    .set{ch_boltz_input}
+        .map { meta, file -> [meta, file, []] }  // already in YAML
+        .mix(BOLTZ_FASTA.out.formatted_fasta)    // newly converted from FASTA
+        .set { ch_boltz_input }
 
     RUN_BOLTZ(
         ch_boltz_input.map{[it[0], it[1]]},

--- a/workflows/boltz.nf
+++ b/workflows/boltz.nf
@@ -53,10 +53,12 @@ workflow BOLTZ {
     msa_server
 
     main:
-    ch_samplesheet.branch {
-    fasta: it[1].extension == "fasta" || it[1].extension == "fa"
-    yaml: it[1].extension == "yaml" || it[1].extension == "yml"
-    }.set { ch_input_by_ext }
+    ch_samplesheet
+        .branch {
+            fasta: it[1].extension == "fasta" || it[1].extension == "fa"
+            yaml: it[1].extension == "yaml" || it[1].extension == "yml"
+        }
+        .set { ch_input_by_ext }
 
     ch_input_by_ext.fasta.join(
         ch_input_by_ext.fasta.map{[it[0], it[1].text.findAll {letter -> letter == ">" }.size()]}

--- a/workflows/boltz.nf
+++ b/workflows/boltz.nf
@@ -60,8 +60,16 @@ workflow BOLTZ {
         }
         .set { ch_input_by_ext }
 
-    ch_input_by_ext.fasta.join(
-        ch_input_by_ext.fasta.map{[it[0], it[1].text.findAll {letter -> letter == ">" }.size()]}
+    ch_input_by_ext.fasta
+        .join(
+            ch_input_by_ext.fasta
+                .map { meta, file ->
+                    [
+                        meta,
+                        file.text.findAll { letter -> letter == ">" }.size()
+                    ]
+                }
+        )
     )
     .map{
         def meta = it[0].clone()


### PR DESCRIPTION

This PR adds support for **YAML-formatted inputs** to the pipeline when using `--mode boltz`. This feature enables users to define **covalent modifications** and **structural constraints**, expanding the scope of Boltz predictions from simple folding to **functionally modified protein design**. This update follows similar functionality as rosettafold and helixfold implementations for handling YAML files.

### Implementation Details `--mode boltz`

- The `--input` samplesheet can now contain `.yaml` files in addition to `.fasta`.
- The pipeline detects input format and branches accordingly:
  - `.yaml` files are passed directly to Boltz
  - `.fasta` files follow the standard preprocessing workflow (e.g., MSA generation, YAML conversion)
  
### Caveats
Currently, this implementation does not modify or validate YAML MSA contents. This means:
- If `--boltz_use_msa_server` is `false`, the YAML **must include a valid MSA block with a precomputed MSA**, otherwise the pipeline will fail
- If `--boltz_use_msa_server` is `true`, Boltz automatically calls an external API to generate the MSA.

### I tested and confirmed:
- A user can run the `proteinfold` pipeline from the command line using a YAML input with a precomputed MSA.
- Arbitrary covalent modifications or structural constraints can be specified in the YAML.
- The Boltz module will consume these modifications and produce structure predictions accordingly.


## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`nf-core lint`).
- [x] `CHANGELOG.md` is updated.
