### PR TITLE
Remove unneccesary params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #333](https://github.com/nf-core/proteinfold/pull/333)] - Updates the RFAA dockerfile for better versioning and smaller image size.
 - [[PR #335](https://github.com/nf-core/proteinfold/pull/335)] - Update pipeline template to [nf-core/tools 3.3.1](https://github.com/nf-core/tools/releases/tag/3.3.1).
 - [[PR #346](https://github.com/nf-core/proteinfold/pull/346)] - Update pipeline template to [nf-core/tools 3.3.2](https://github.com/nf-core/tools/releases/tag/3.3.2).
+- [[PR #355](https://github.com/nf-core/proteinfold/pull/355)] - Remove unneccesary params from Boltz and Helixfold3 modes.
 
 ### Parameters
 

--- a/conf/modules_boltz.config
+++ b/conf/modules_boltz.config
@@ -13,13 +13,11 @@
 process {
     withName: 'RUN_BOLTZ' {
         ext.args = [
-            params.boltz_model                      ? "--model ${params.boltz_model}"                                       : "",
-            params.boltz_out_dir                    ? "--out_dir ${params.boltz_out_dir}"                                       : "",
-            params.boltz_output_format              ? "--output_format ${params.boltz_output_format}"                           : "",
+            params.boltz_model                      ? "--model ${params.boltz_model}"                                           : "",
             params.boltz_use_msa_server             ? "--use_msa_server"                                                        : "",
             params.boltz_msa_server_url             ? "--msa_server_url ${params.boltz_msa_server_url}"                         : "",
             params.boltz_use_potentials             ? "--use_potentials"                                                        : "",
-            params.boltz_write_full_pae             ? "--write_full_pae"                                                        : "",
+            "--write_full_pae",
         ].findAll{ it }.join(' ').trim()
 
         publishDir = [

--- a/conf/modules_helixfold3.config
+++ b/conf/modules_helixfold3.config
@@ -25,10 +25,10 @@ process {
 
         ext.args = [
             params.helixfold3_max_template_date ? "--max_template_date=${params.helixfold3_max_template_date}" : "--max_template_date=2038-01-19",
-            params.model_name        ? "--model_name ${params.model_name}"               : "--model_name allatom_demo",
+            "--model_name allatom_demo",
             params.preset            ? "--preset ${params.preset}"                       : "--preset 'reduced_dbs'",
             params.init_model        ? "--init_model ${params.init_model}"               : "--init_model './init_models/HelixFold3-240814.pdparams'",
-            params.logging_level     ? "--logging_level ${params.logging_level}"         : "--logging_level 'ERROR'",
+            "--logging_level 'ERROR'",
             params.precision         ? "--precision ${params.precision}"                 : "--precision 'bf16'",
             params.infer_times       ? "--infer_times ${params.infer_times}"             : "--infer_times 4"
         ].join(' ').trim()

--- a/conf/modules_helixfold3.config
+++ b/conf/modules_helixfold3.config
@@ -27,7 +27,6 @@ process {
             params.helixfold3_max_template_date ? "--max_template_date=${params.helixfold3_max_template_date}" : "--max_template_date=2038-01-19",
             "--model_name allatom_demo",
             params.preset            ? "--preset ${params.preset}"                       : "--preset 'reduced_dbs'",
-            params.init_model        ? "--init_model ${params.init_model}"               : "--init_model './init_models/HelixFold3-240814.pdparams'",
             "--logging_level 'ERROR'",
             params.precision         ? "--precision ${params.precision}"                 : "--precision 'bf16'",
             params.infer_times       ? "--infer_times ${params.infer_times}"             : "--infer_times 4"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -594,11 +594,9 @@ nextflow run nf-core/proteinfold \
 | Parameter                | Default | Description                                         |
 | ------------------------ | ------- | --------------------------------------------------- |
 | `--boltz_model`          | `null`  | The model to use for prediction. Default is Boltz-2 |
-| `--boltz_out_dir`        | `null`  | Output directory for Boltz predictions              |
 | `--boltz_use_msa_server` | `null`  | Use MSA server to generate MSAs (flag)              |
 | `--boltz_msa_server_url` | `null`  | MSA server URL                                      |
 | `--boltz_use_potentials` | `null`  | Use inference time potentials (flag)                |
-| `--boltz_write_full_pae` | `true`  | Save the full PAE matrix as a file (flag)           |
 
 > You can override any of these parameters via the command line or a params file.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -392,7 +392,6 @@ nextflow run nf-core/proteinfold \
 ## Optional parameters with default values:
     --helixfold3_max_template_date=2038-01-19
     --preset 'reduced_dbs'
-    --init_model './init_models/HelixFold3-240814.pdparams'
     --precision 'bf16'
     --infer_times 4
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -391,10 +391,8 @@ nextflow run nf-core/proteinfold \
 ```console
 ## Optional parameters with default values:
     --helixfold3_max_template_date=2038-01-19
-    --model_name allatom_demo
     --preset 'reduced_dbs'
     --init_model './init_models/HelixFold3-240814.pdparams'
-    --logging_level 'ERROR'
     --precision 'bf16'
     --infer_times 4
 ```

--- a/modules/local/run_helixfold3/main.nf
+++ b/modules/local/run_helixfold3/main.nf
@@ -46,6 +46,8 @@ process RUN_HELIXFOLD3 {
     }
     def args = task.ext.args ?: ''
     """
+    init_model_path=\$(ls ./init_models/*.pdparams | head -n 1)
+
     mamba run --name helixfold python3.9 /app/helixfold3/inference.py \\
         --maxit_binary "./maxit_src/bin/maxit" \\
         --jackhmmer_binary_path "jackhmmer" \\
@@ -67,7 +69,9 @@ process RUN_HELIXFOLD3 {
         --uniref90_database_path "./uniref90/uniref90.fasta" \\
         --mgnify_database_path "./mgnify/mgy_clusters.fa" \\
         --input_json="${fasta}" \\
-        --output_dir="\$PWD" $args
+        --output_dir="\$PWD" \\
+        --init_model "\$init_model_path" \\
+        $args
 
     cp "${fasta.baseName}/${fasta.baseName}-rank1/predicted_structure.pdb" "./${meta.id}_helixfold3.pdb"
     cp "${fasta.baseName}/${fasta.baseName}-rank1/predicted_structure.cif" "./${meta.id}_helixfold3.cif"

--- a/nextflow.config
+++ b/nextflow.config
@@ -143,7 +143,6 @@ params {
     // Helixfold3 parameters
     helixfold3_db                = null
     preset                       = null
-    init_model                   = null
     precision                    = null
     infer_times                  = null
     helixfold3_max_template_date = "2038-01-19"

--- a/nextflow.config
+++ b/nextflow.config
@@ -142,10 +142,8 @@ params {
 
     // Helixfold3 parameters
     helixfold3_db                = null
-    model_name                   = null
     preset                       = null
     init_model                   = null
-    logging_level                = null
     precision                    = null
     infer_times                  = null
     helixfold3_max_template_date = "2038-01-19"

--- a/nextflow.config
+++ b/nextflow.config
@@ -74,12 +74,9 @@ params {
 
     // Boltz parameters
     boltz_model                      = null
-    boltz_out_dir                    = null
-    boltz_output_format              = 'pdb'
     boltz_use_msa_server             = false
     boltz_msa_server_url             = null
     boltz_use_potentials             = false
-    boltz_write_full_pae             = true
 
     // Boltz links
     boltz_ccd_link       = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -298,9 +298,6 @@
                 "preset": {
                     "type": "string"
                 },
-                "init_model": {
-                    "type": "string"
-                },
                 "precision": {
                     "type": "string"
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -247,18 +247,11 @@
                     "description": "Use the cloud MSA server",
                     "icon": "fas folder-open"
                 },
-                "boltz_out_dir": {
-                    "type": "string"
-                },
                 "boltz_msa_server_url": {
                     "type": "string"
                 },
                 "boltz_use_potentials": {
                     "type": "boolean"
-                },
-                "boltz_write_full_pae": {
-                    "type": "boolean",
-                    "default": true
                 },
                 "boltz_model": {
                     "type": "string"
@@ -1190,11 +1183,5 @@
         {
             "$ref": "#/$defs/helixfold3_dbs_and_parameters_link_options"
         }
-    ],
-    "properties": {
-        "boltz_output_format": {
-            "type": "string",
-            "default": "pdb"
-        }
-    }
+    ]
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -295,16 +295,10 @@
             "description": "HelixFold3 options",
             "default": "",
             "properties": {
-                "model_name": {
-                    "type": "string"
-                },
                 "preset": {
                     "type": "string"
                 },
                 "init_model": {
-                    "type": "string"
-                },
-                "logging_level": {
                     "type": "string"
                 },
                 "precision": {


### PR DESCRIPTION
- Removed the following params from boltz mode:
  - write_full_pae: PAE report is required for downstream pipeline. Negligible time to produce. No reason to turn it off
  - boltz_out_dir: This will affect where files end up in nf work directory. May break downstream channels.
  - boltz_output_format: Downstream modules require PDB format. Vast majority of predictions will be compatible with PDB. May want to add general support for cif in future release.

- Removed the following params from helixfold3 mode:
  - logging_level: No reason to change from default.
  - model_name: No reason to change from default.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
