### PR TITLE
Update boltz Dockerfile and image pinging specific version (2.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #332](https://github.com/nf-core/proteinfold/pull/332)] - Fix rare superposition bug in reports.
 - [[PR #333](https://github.com/nf-core/proteinfold/pull/333)] - Updates the RFAA dockerfile for better versioning and smaller image size.
 - [[PR #335](https://github.com/nf-core/proteinfold/pull/335)] - Update pipeline template to [nf-core/tools 3.3.1](https://github.com/nf-core/tools/releases/tag/3.3.1).
-- [[PR #346](https://github.com/nf-core/proteinfold/pull/346)] - Update pipeline template to [nf-core/tools 3.3.2](https://github.com/nf-core/tools/releases/tag/3.3.2).
 - [[PR #355](https://github.com/nf-core/proteinfold/pull/355)] - Remove unneccesary params from Boltz and Helixfold3 modes.
+- [[PR #362](https://github.com/nf-core/proteinfold/pull/355)] - Update boltz Dockerfile and image pinging specific version (2.0.3).
 
 ### Parameters
 

--- a/dockerfiles/Dockerfile_nfcore-proteinfold_boltz
+++ b/dockerfiles/Dockerfile_nfcore-proteinfold_boltz
@@ -12,6 +12,14 @@ RUN apt-get update && \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir boltz
+RUN pip install --no-cache-dir boltz==2.0.3
+
+## To update to version 2.2.0, uncomment the following lines, though still was complaining
+## about triton version, thought the error msg state to be sure of using 3.3.0
+# RUN pip install --no-cache-dir \
+#     cuequivariance_ops_cu12==0.5.1\
+#     cuequivariance_ops_torch_cu12==0.5.1 \
+#     cuequivariance_torch==0.5.1 \
+#     triton==3.3.0
 
 CMD ["boltz"]

--- a/modules/local/run_boltz/main.nf
+++ b/modules/local/run_boltz/main.nf
@@ -72,7 +72,7 @@ process RUN_BOLTZ {
     """
 
     stub:
-    def version = "0.4.1"
+    def version = "2.0.3"
     """
     mkdir -p boltz_results_${meta.id}/processed/msa/
     mkdir -p boltz_results_${meta.id}/processed/structures/

--- a/modules/local/run_boltz/main.nf
+++ b/modules/local/run_boltz/main.nf
@@ -56,11 +56,10 @@ process RUN_BOLTZ {
     export NUMBA_CACHE_DIR=/tmp
     export HOME=/tmp
 
-    boltz predict "${fasta}" ${args}
+    boltz predict "${fasta}" --output_format "pdb" ${args}
     cp boltz_results_*/predictions/*/*.pdb ./${meta.id}_boltz.pdb
 
     extract_metrics.py --name ${meta.id} \\
-        --output_format "pdb" \\
         --structs boltz_results_*/predictions/${meta.id}/*.pdb \\
         --jsons boltz_results_*/predictions/${meta.id}/confidence_*_model_*.json \\
         --npzs boltz_results_*/predictions/${meta.id}/pae_*_model_*.npz \\

--- a/modules/local/run_boltz/main.nf
+++ b/modules/local/run_boltz/main.nf
@@ -60,6 +60,7 @@ process RUN_BOLTZ {
     cp boltz_results_*/predictions/*/*.pdb ./${meta.id}_boltz.pdb
 
     extract_metrics.py --name ${meta.id} \\
+        --output_format "pdb" \\
         --structs boltz_results_*/predictions/${meta.id}/*.pdb \\
         --jsons boltz_results_*/predictions/${meta.id}/confidence_*_model_*.json \\
         --npzs boltz_results_*/predictions/${meta.id}/pae_*_model_*.npz \\


### PR DESCRIPTION
Update boltz image after pinging version `2.0.3`, the image `quay.io/nf-core/proteinfold_boltz:dev` has also been updated though in principle the version was the same version.
N.B the image has not been updated to the latest version as it needs other dependencies (left some comments on the Dockerfile)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] `CHANGELOG.md` is updated.
