### PR TITLE
fix sequence msa synch for af2 split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #370](https://github.com/nf-core/proteinfold/pull/370)] - Fix extract chain metrics.
 - [[#367](https://github.com/nf-core/proteinfold/issues/367)] - Boltz post-processing crashes.
 - [[#368](https://github.com/nf-core/proteinfold/issues/368)] - Helixfold3 iPTM output missing when dealing with monomers make the process to fail.
+- [[PR #377](https://github.com/nf-core/proteinfold/pull/377)] - Fix sequence msa synch for af2 split.
 
 ### Parameters
 

--- a/modules/local/run_alphafold2_pred/main.nf
+++ b/modules/local/run_alphafold2_pred/main.nf
@@ -23,7 +23,7 @@ process RUN_ALPHAFOLD2_PRED {
     path ('pdb_seqres/*')
     path ('uniprot/*')
     // TODO: do we ever really want to be dragging arounda  meta2? Can't we just augment meta fields for tracebility?
-    tuple val(meta2), path(features)
+    tuple val(meta), path(features)
 
     output:
     path ("${fasta.baseName}*")

--- a/workflows/alphafold2.nf
+++ b/workflows/alphafold2.nf
@@ -116,8 +116,17 @@ workflow ALPHAFOLD2 {
         )
         ch_versions = ch_versions.mix(RUN_ALPHAFOLD2_MSA.out.versions)
 
+        //synchronize
+        ch_samplesheet.join(
+            RUN_ALPHAFOLD2_MSA.out.features,
+        )
+        .set { ch_synched }
+
+        def ch_samplesheet2 = ch_synched.map{meta, seq, msa -> [meta, seq]}
+        def ch_features = ch_synched.map{meta, seq, msa -> [meta, msa]}
+
         RUN_ALPHAFOLD2_PRED (
-            ch_samplesheet,
+            ch_samplesheet2,
             alphafold2_model_preset,
             ch_alphafold2_params,
             ch_bfd,
@@ -130,7 +139,7 @@ workflow ALPHAFOLD2 {
             ch_uniref90,
             ch_pdb_seqres,
             ch_uniprot,
-            RUN_ALPHAFOLD2_MSA.out.features
+            ch_features
         )
 
         RUN_ALPHAFOLD2_PRED


### PR DESCRIPTION
Joined samplesheet and feature channels on meta.id in AF2 split mode to ensure the order is consistent between channels.

Closes #376 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] `CHANGELOG.md` is updated.
