### PR TITLE
Lock version numbers for HelixFold3 image, fixes #389

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#378](https://github.com/nf-core/proteinfold/issues/378)] - Fix nested obsolete pdbs from pdb70.
 - [[#388](https://github.com/nf-core/proteinfold/issues/388)] - Fix colabfold prefix handling for output metrics.
 - [[#387](https://github.com/nf-core/proteinfold/issues/387)] - Fix alphafold2_standard obsolete.dat path error.
+- [[#389](https://github.com/nf-core/proteinfold/issues/389)] - Locked version numbers for HelixFold3 image to prevent bug caused by newer mamba versions.
 
 ### Parameters
 

--- a/modules/local/run_helixfold3/Dockerfile
+++ b/modules/local/run_helixfold3/Dockerfile
@@ -1,16 +1,16 @@
 ARG CUDA=12.8.1
-FROM nvidia/cuda:${CUDA}-cudnn-devel-ubuntu22.04 AS builder
+FROM nvidia/cuda:${CUDA}-cudnn-devel-ubuntu22.04
 # FROM directive resets ARGS, so we specify again (the value is retained if
 # previously set).
 ARG CUDA
 
 LABEL Author="j.caley@unsw.edu.au, Jose Espinosa-Carrasco" \
     title="nfcore/proteinfold_helixfold3" \
-    Version="1.2.0dev" \
+    Version="2.0.0dev" \
     description="Docker image containing all software requirements to run the RUN_HELIXFOLD3 module using the nf-core/proteinfold pipeline"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y wget git && \
-    wget -q -P /tmp "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \
+    wget -q -P /tmp "https://github.com/conda-forge/miniforge/releases/download/24.11.0-0/Miniforge3-$(uname)-$(uname -m).sh" && \
     bash /tmp/Miniforge3-$(uname)-$(uname -m).sh -b -p /conda && \
     git clone --filter=blob:none --no-checkout https://github.com/PaddlePaddle/PaddleHelix.git /app/helixfold3 && \
     cd /app/helixfold3 && \
@@ -21,7 +21,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     rm -rf /tmp/Miniforge3-$(uname)-$(uname -m).sh /var/lib/apt/lists/* /root/.cache apps && \
     apt-get remove --purge -y wget git && apt-get autoremove -y && apt-get clean -y
 
-COPY environment_nfcore-proteinfold_helixfold3.yaml /app/helixfold3/environment.yaml
+COPY environment.yaml /app/helixfold3/environment.yaml
 
 ENV PATH="/conda/bin:$PATH"
 
@@ -31,17 +31,11 @@ RUN mamba env create --file=/app/helixfold3/environment.yaml && \
     mamba clean --all --force-pkgs-dirs -y && \
     rm -rf /root/.cache
 
-FROM nvidia/cuda:${CUDA}-cudnn-devel-ubuntu22.04
-# FROM directive resets ARGS, so we specify again (the value is retained if
-# previously set).
-ARG CUDA
-
-COPY --from=builder /app /app
-COPY --from=builder /conda /conda
-
 ENV PATH="/conda/bin:/app/helixfold3:./maxit_src/bin:/conda/envs/helixfold/bin:$PATH" \
     RCSBROOT="./maxit_src" \
     MAXIT_SRC="./maxit_src" \
     PYTHON_BIN="/conda/envs/helixfold/bin/python3.9" \
     ENV_BIN="/conda/envs/helixfold/bin" \
     OBABEL_BIN="/conda/envs/helixfold/bin"
+
+ENTRYPOINT ["mamba", "run", "--name", "helixfold"]

--- a/modules/local/run_helixfold3/environment.yaml
+++ b/modules/local/run_helixfold3/environment.yaml
@@ -10,14 +10,14 @@ dependencies:
   - cuda-toolkit=12.0
   - cudnn=8.4.0
   - nccl=2.14
-  - libgcc
-  - libgomp
-  - pip
-  - aria2
-  - hmmer==3.4
-  - kalign2==2.04
-  - hhsuite==3.3.0
-  - openbabel
+  - libgcc=14.2.0
+  - libgomp=14.2.0
+  - pip=25.0.1
+  - aria2=1.37.0
+  - hmmer=3.4
+  - kalign2=2.04
+  - hhsuite=3.3.0
+  - openbabel=3.1.1
   - pip:
       - paddlepaddle-gpu==2.6.1 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
       - absl-py==0.13.0
@@ -32,4 +32,4 @@ dependencies:
       - pandas==1.3.4
       - scipy==1.9.0
       - rdkit-pypi==2022.9.5
-      - posebusters
+      - posebusters==0.3.6


### PR DESCRIPTION
Locks dependency version numbers in `environment.yml` and `Dockerfile` to prevent instability from upstream updates.
Addresses [#389](https://github.com/nf-core/proteinfold/issues/389).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.