### PR TITLE
typo fix in samplesheet cols description, and allow for .faa files?

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -23,7 +23,7 @@
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+\\.(fa(sta)?|yaml|yml|json)$",
+                "pattern": "^\\S+\\.(fa(sta)?|faa|yaml|yml|json)$",
                 "errorMessage": "Fasta, yaml or json file must be provided, cannot contain spaces and must have extension '.fa', '.fasta', '.yaml', '.yml', or '.json'"
             }
         },

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,7 +21,7 @@ You will need to create a samplesheet with information about the sequences you w
 A sample of the final samplesheet file for two sequences is shown below:
 
 ```csv title="samplesheet.csv"
-sequence,fasta
+id,fasta
 T1024,https://raw.githubusercontent.com/nf-core/test-datasets/proteinfold/testdata/sequences/T1024.fasta
 T1026,https://raw.githubusercontent.com/nf-core/test-datasets/proteinfold/testdata/sequences/T1026.fasta
 ```


### PR DESCRIPTION
Swapped `sequence` to `id`.
I also added `faa` (amino acid fasta format -stated explicitly) on the allowed formats inside the fasta column of the samplesheet schema. Will this work or is there a check downstream that would break?

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfold _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
