### PR TITLE
Clean ESMFold outputs  |  --env flags for apptainer enginer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #461](https://github.com/nf-core/proteinfold/pulls/461)] - Update publishdir patterns for HelixFold3 module
 - [[PR #462](https://github.com/nf-core/proteinfold/pulls/462)] - Update publishdir patterns for RoseTTAFold-All-Atom modules
 - [[PR #464](https://github.com/nf-core/proteinfold/pulls/454)] - Update publishdir patterns for Boltz module
-- [[PR #464](https://github.com/nf-core/proteinfold/pulls/464)] - Update module conf and publishdir patterns for ESMFold, pass through container args
+- [[PR #466](https://github.com/nf-core/proteinfold/pulls/464)] - Update module conf and publishdir patterns for ESMFold, pass through container args
 - [[PR #469](https://github.com/nf-core/proteinfold/pulls/454)] - HTML reports now in /reports output directory
 
 ### Parameters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #451](https://github.com/nf-core/proteinfold/pulls/451)] - Remove af2 multimer padding from msa plots.
 - [[#417](https://github.com/nf-core/proteinfold/issues/417)] - Add `boltz_use_kernels` parameter to enable/disable using optimized Triton-based CUDA kernels CUDA kernels for Boltz inference.
 - [[#285](https://github.com/nf-core/proteinfold/issues/285)] - Adding contributors to manifest.
+- [[PR #460](https://github.com/nf-core/proteinfold/pulls/460)] - Use `nvidia-smi` to obtain number of SM.
 - [[PR #454](https://github.com/nf-core/proteinfold/pulls/454)] - Update publishdir patterns for alphafold2 modules.
 - [[PR #458](https://github.com/nf-core/proteinfold/pulls/458)] - Update publishdir patterns for colabfold module.
 - [[#313](https://github.com/nf-core/proteinfold/issues/313)] - Harmonize colabfold metrics extraction with other modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#417](https://github.com/nf-core/proteinfold/issues/417)] - Add `boltz_use_kernels` parameter to enable/disable using optimized Triton-based CUDA kernels CUDA kernels for Boltz inference.
 - [[#417](https://github.com/nf-core/proteinfold/issues/417)] - Handle incompatible CUDA kernel errors in Boltz by automatically retrying with `--no_kernels` false.
 - [[PR #454](https://github.com/nf-core/proteinfold/pulls/454)] - Update publishdir patterns for alphafold2 modules
+- [[PR #464](https://github.com/nf-core/proteinfold/pulls/464)] - Update module conf and publishdir patterns for ESMFold, pass through container args
 
 ### Parameters
 

--- a/conf/modules_esmfold.config
+++ b/conf/modules_esmfold.config
@@ -13,6 +13,11 @@
 process {
     withName: 'RUN_ESMFOLD' {
         ext.args = {params.use_gpu ? '' : '--cpu-only'}
+        containerOptions = {
+          workflow.containerEngine in ['singularity', 'apptainer'] ? 
+          '--nv --env TRITON_CACHE_DIR=/tmp/triton_cache --env XDG_CACHE_HOME=/tmp' : 
+          ''
+        }
         publishDir = [
             [
                 path: { "${params.outdir}/esmfold/${meta.id}" },

--- a/conf/modules_esmfold.config
+++ b/conf/modules_esmfold.config
@@ -14,8 +14,8 @@ process {
     withName: 'RUN_ESMFOLD' {
         ext.args = {params.use_gpu ? '' : '--cpu-only'}
         containerOptions = {
-          workflow.containerEngine in ['singularity', 'apptainer'] ? 
-          '--nv --env TRITON_CACHE_DIR=/tmp/triton_cache --env XDG_CACHE_HOME=/tmp' : 
+          workflow.containerEngine in ['singularity', 'apptainer'] ?
+          '--nv --env TRITON_CACHE_DIR=/tmp/triton_cache --env XDG_CACHE_HOME=/tmp' :
           ''
         }
         publishDir = [

--- a/conf/modules_esmfold.config
+++ b/conf/modules_esmfold.config
@@ -13,7 +13,6 @@
 process {
     withName: 'RUN_ESMFOLD' {
         ext.args = {params.use_gpu ? '' : '--cpu-only'}
-        containerOptions = '--nv --env TRITON_CACHE_DIR=/tmp/triton_cache --env XDG_CACHE_HOME=/tmp'
         publishDir = [
             [
                 path: { "${params.outdir}/esmfold/${meta.id}" },

--- a/conf/modules_esmfold.config
+++ b/conf/modules_esmfold.config
@@ -12,7 +12,7 @@
 
 process {
     withName: 'RUN_ESMFOLD' {
-        ext.args = ''
+        ext.args = {params.use_gpu ? '' : '--cpu-only'}
         containerOptions = '--nv --env TRITON_CACHE_DIR=/tmp/triton_cache --env XDG_CACHE_HOME=/tmp'
         publishDir = [
             [

--- a/conf/modules_esmfold.config
+++ b/conf/modules_esmfold.config
@@ -13,7 +13,7 @@
 process {
     withName: 'RUN_ESMFOLD' {
         ext.args = ''
-        containerOptions = '--nv --env TRITON_CACHE_DIR=/tmp/triton_cache --env XDG_CACHE_HOME=/tmp'  
+        containerOptions = '--nv --env TRITON_CACHE_DIR=/tmp/triton_cache --env XDG_CACHE_HOME=/tmp'
         publishDir = [
             [
                 path: { "${params.outdir}/esmfold/${meta.id}" },

--- a/conf/modules_esmfold.config
+++ b/conf/modules_esmfold.config
@@ -12,19 +12,19 @@
 
 process {
     withName: 'RUN_ESMFOLD' {
-        ext.args = {params.use_gpu ? '' : '--cpu-only'}
+        ext.args = ''
+        containerOptions = '--nv --env TRITON_CACHE_DIR=/tmp/triton_cache --env XDG_CACHE_HOME=/tmp'  
         publishDir = [
             [
-                path: { "${params.outdir}/esmfold/default" },
+                path: { "${params.outdir}/esmfold/${meta.id}" },
                 mode: 'copy',
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-                pattern: '*.*'
+                pattern: '*_plddt.tsv'
             ],
             [
-                path: { "${params.outdir}/esmfold/default/top_ranked_structures" },
+                path: { "${params.outdir}/esmfold/top_ranked_structures" },
                 mode: 'copy',
                 saveAs: { "${meta.id}.pdb" },
-                pattern: '*.pdb'
+                pattern: '*_esmfold.pdb'
             ]
         ]
     }


### PR DESCRIPTION
Tidies ESMFold outputs, since the module doesn't generate un-wanted intermediates:
- Publishing rules to match output layout from #454 
- Fixes #463 by passing flags in `conf/modules_esmfold.config` (to avoid cluttering `nextflow.config` earlier stated)
- removes  `ext.args = {params.use_gpu ? '' : '--cpu-only'}` as ESMFold is unjustifiable on a slow CPU execution, and future compatibility for unmaintained model will be harder as Compute Compatbility of cards changes

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
