### PR TITLE
Allow AlphaFold3 JSON files as direct samplesheet input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #597](https://github.com/nf-core/proteinfold/pull/249)] - Update pipeline template to [nf-core/tools 4.0.2](https://github.com/nf-core/tools/releases/tag/4.0.2).
 - [[#598](https://github.com/nf-core/proteinfold/issues/598)] - Remove workflow JSON generation.
 - [[#600](https://github.com/nf-core/proteinfold/issues/600)] - Fix multiqc reports publication and centralize the config in `modules.config`.
+- [[#603](https://github.com/nf-core/proteinfold/issues/603)] - Allow AlphaFold3 JSON files as direct samplesheet input, bypassing `FASTA_TO_ALPHAFOLD3_JSON`.
 
 | Old parameter              | New parameter   |
 | -------------------------- | --------------- |

--- a/workflows/alphafold3.nf
+++ b/workflows/alphafold3.nf
@@ -43,14 +43,22 @@ workflow ALPHAFOLD3 {
     ch_msa_final      = channel.empty()
     ch_multiqc_report = channel.empty()
 
-    FASTA_TO_ALPHAFOLD3_JSON(ch_samplesheet)
-    ch_versions       = ch_versions.mix(FASTA_TO_ALPHAFOLD3_JSON.out.versions)
+    ch_samplesheet
+        .branch { it ->
+            fasta: it[1].extension == "fasta" || it[1].extension == "fa"
+            json: it[1].extension == "json"
+    }.set { ch_input_by_ext }
+
+    FASTA_TO_ALPHAFOLD3_JSON(ch_input_by_ext.fasta)
+    ch_versions = ch_versions.mix(FASTA_TO_ALPHAFOLD3_JSON.out.versions)
+
+    ch_json = ch_input_by_ext.json.mix(FASTA_TO_ALPHAFOLD3_JSON.out.json)
 
     //
     // SUBWORKFLOW: Run AlphaFold3
     //
     RUN_ALPHAFOLD3 (
-        FASTA_TO_ALPHAFOLD3_JSON.out.json,
+        ch_json,
         ch_alphafold3_params,
         ch_small_bfd,
         ch_mgnify,


### PR DESCRIPTION
Branch ch_samplesheet in alphafold3.nf by file extension: `.json` files are passed directly to `RUN_ALPHAFOLD3`, while `fasta` files continue through `FASTA_TO_ALPHAFOLD3_JSON` as before.

Closes #603 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
