### PR TITLE
Fix Nextflow 26.04.1 warnings when using file() in globs and other small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#600](https://github.com/nf-core/proteinfold/issues/600)] - Fix multiqc reports publication and centralize the config in `modules.config`.
 - [[#602](https://github.com/nf-core/proteinfold/issues/602)] - Fix file name collision when staging ColabFold databases to the same directory in `MMSEQS_COLABFOLDSEARCH`.
 - [[#603](https://github.com/nf-core/proteinfold/issues/603)] - Allow AlphaFold3 JSON files as direct samplesheet input, bypassing `FASTA_TO_ALPHAFOLD3_JSON`.
+- [[#607](https://github.com/nf-core/proteinfold/pull/607)] - Fix Nextflow 26.04.1 warnings when using glob patterns in `file()` and other small fixes.
 
 | Old parameter              | New parameter   |
 | -------------------------- | --------------- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [[PR #573](https://github.com/nf-core/proteinfold/pull/573)] - Adds affiliations for UNSW Structural Biology Facility (SBF).
 - [[PR #588](https://github.com/nf-core/proteinfold/pulls/588)] - Add `--random_seed` for AF2, Boltz, and ColabFold, removing and replacing `--alphafold2_random_seed`.
-- [[PR #597](https://github.com/nf-core/proteinfold/pull/249)] - Update pipeline template to [nf-core/tools 4.0.2](https://github.com/nf-core/tools/releases/tag/4.0.2).
+- [[PR #597](https://github.com/nf-core/proteinfold/pull/597)] - Update pipeline template to [nf-core/tools 4.0.2](https://github.com/nf-core/tools/releases/tag/4.0.2).
 - [[#598](https://github.com/nf-core/proteinfold/issues/598)] - Remove workflow JSON generation.
 - [[#600](https://github.com/nf-core/proteinfold/issues/600)] - Fix multiqc reports publication and centralize the config in `modules.config`.
 - [[#602](https://github.com/nf-core/proteinfold/issues/602)] - Fix file name collision when staging ColabFold databases to the same directory in `MMSEQS_COLABFOLDSEARCH`.

--- a/conf/test_full_alphafold_split.config
+++ b/conf/test_full_alphafold_split.config
@@ -22,8 +22,6 @@ params {
     alphafold2_db   = 's3://proteinfold-dataset/test-data/mini_dbs'
 }
 
-docker.pullStrategy = 'lazy'
-
 process {
     withName: 'RUN_ALPHAFOLD2_PRED' {
         beforeScript = System.getenv('TOWER_WORKFLOW_ID') ? 'unset LD_LIBRARY_PATH && export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/lib && export OPENMM_CUDA_COMPILER=/opt/conda/bin/nvcc && export TMPDIR=/tmp' : null

--- a/conf/test_full_boltz.config
+++ b/conf/test_full_boltz.config
@@ -22,8 +22,6 @@ params {
     boltz_db                = 's3://proteinfold-dataset/test-data/mini_dbs/'
 }
 
-docker.pullStrategy = 'lazy'
-
 process {
     withName: 'RUN_BOLTZ' {
         memory = '20 GB'

--- a/conf/test_full_colabfold_local.config
+++ b/conf/test_full_colabfold_local.config
@@ -25,8 +25,6 @@ params {
     colabfold_use_templates = false
 }
 
-docker.pullStrategy = 'lazy'
-
 process {
     withName:MMSEQS_COLABFOLDSEARCH {
         memory = 16.GB

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,54 +10,54 @@
 params {
 
     // Input options
-    input                       = null
-    mode                        = 'alphafold2' // {alphafold2, colabfold, esmfold, rosettafold_all_atom, alphafold3, helixfold3, boltz, rosettafold2na}
-    use_gpu                     = false
-    save_intermediates          = false
-    split_fasta                 = false
-    db                          = null
-    full_dbs                    = false // true/false, globally sets full_dbs if not independently set
-    use_msa_server              = false
-    msa_server_url              = null
-    uniref30_prefix             = null
-    random_seed                 = null
+    input              = null
+    mode               = 'alphafold2' // {alphafold2, colabfold, esmfold, rosettafold_all_atom, alphafold3, helixfold3, boltz, rosettafold2na}
+    use_gpu            = false
+    save_intermediates = false
+    split_fasta        = false
+    db                 = null
+    full_dbs           = false // true/false, globally sets full_dbs if not independently set
+    use_msa_server     = false
+    msa_server_url     = null
+    uniref30_prefix    = null
+    random_seed        = null
 
     // Alphafold2 parameters
-    alphafold2_mode                 = 'split_msa_prediction' // {standard, split_msa_prediction}
-    alphafold2_max_template_date    = '2038-01-19'
-    alphafold2_full_dbs             = null // true full_dbs, false reduced_dbs
-    alphafold2_model_preset         = 'monomer_ptm' // single-entry FASTA only: {monomer, monomer_casp14, monomer_ptm}
-    alphafold2_db                   = null
+    alphafold2_mode              = 'split_msa_prediction' // {standard, split_msa_prediction}
+    alphafold2_max_template_date = '2038-01-19'
+    alphafold2_full_dbs          = null // true full_dbs, false reduced_dbs
+    alphafold2_model_preset      = 'monomer_ptm' // single-entry FASTA only: {monomer, monomer_casp14, monomer_ptm}
+    alphafold2_db                = null
 
     // Alphafold2 links
-    alphafold2_bfd_link             = null
-    alphafold2_small_bfd_link       = null
-    alphafold2_params_link          = null
-    alphafold2_mgnify_link          = null
-    alphafold2_pdb70_link           = null
-    alphafold2_pdb_mmcif_link       = null
-    alphafold2_pdb_obsolete_link    = null
-    alphafold2_uniref30_link        = null
-    alphafold2_uniref90_link        = null
-    alphafold2_pdb_seqres_link      = null
-    alphafold2_uniprot_sprot_link   = null
-    alphafold2_uniprot_trembl_link  = null
+    alphafold2_bfd_link            = null
+    alphafold2_small_bfd_link      = null
+    alphafold2_params_link         = null
+    alphafold2_mgnify_link         = null
+    alphafold2_pdb70_link          = null
+    alphafold2_pdb_mmcif_link      = null
+    alphafold2_pdb_obsolete_link   = null
+    alphafold2_uniref30_link       = null
+    alphafold2_uniref90_link       = null
+    alphafold2_pdb_seqres_link     = null
+    alphafold2_uniprot_sprot_link  = null
+    alphafold2_uniprot_trembl_link = null
 
     // Alphafold2 paths
-    alphafold2_bfd_path             = null
-    alphafold2_small_bfd_path       = null
-    alphafold2_params_path          = null
-    alphafold2_mgnify_path          = null
-    alphafold2_pdb70_path           = null
-    alphafold2_pdb_mmcif_path       = null
-    alphafold2_pdb_obsolete_path    = null
-    alphafold2_uniref30_path        = null
-    alphafold2_uniref90_path        = null
-    alphafold2_pdb_seqres_path      = null
-    alphafold2_uniprot_path         = null
+    alphafold2_bfd_path          = null
+    alphafold2_small_bfd_path    = null
+    alphafold2_params_path       = null
+    alphafold2_mgnify_path       = null
+    alphafold2_pdb70_path        = null
+    alphafold2_pdb_mmcif_path    = null
+    alphafold2_pdb_obsolete_path = null
+    alphafold2_uniref30_path     = null
+    alphafold2_uniref90_path     = null
+    alphafold2_pdb_seqres_path   = null
+    alphafold2_uniprot_path      = null
 
     // Alphafold3 parameters
-    alphafold3_db              = null
+    alphafold3_db = null
 
     // Alphafold3 links
     alphafold3_small_bfd_link  = null
@@ -88,38 +88,38 @@ params {
     boltz_use_kernels    = true
 
     // Boltz links
-    boltz_ccd_link       = null
-    boltz_model_link     = null
-    boltz2_aff_link      = null
-    boltz2_conf_link     = null
-    boltz2_mols_link     = null
+    boltz_ccd_link   = null
+    boltz_model_link = null
+    boltz2_aff_link  = null
+    boltz2_conf_link = null
+    boltz2_mols_link = null
 
     // Boltz paths
-    boltz_db             = null
-    boltz_ccd_path       = null
-    boltz_model_path     = null
-    boltz2_aff_path      = null
-    boltz2_conf_path     = null
-    boltz2_mols_path     = null
+    boltz_db         = null
+    boltz_ccd_path   = null
+    boltz_model_path = null
+    boltz2_aff_path  = null
+    boltz2_conf_path = null
+    boltz2_mols_path = null
 
     // Colabfold parameters
-    colabfold_num_recycles      = 3
-    colabfold_use_amber         = true
-    colabfold_use_gpu_relax     = false
-    colabfold_db                = null
-    colabfold_db_load_mode      = 0
-    colabfold_use_templates     = false
-    colabfold_create_index      = false
+    colabfold_num_recycles  = 3
+    colabfold_use_amber     = true
+    colabfold_use_gpu_relax = false
+    colabfold_db            = null
+    colabfold_db_load_mode  = 0
+    colabfold_use_templates = false
+    colabfold_create_index  = false
 
     // Colabfold links
-    colabfold_db_link                 = null
-    colabfold_uniref30_link           = null
-    colabfold_alphafold2_params_link  = null
+    colabfold_db_link                = null
+    colabfold_uniref30_link          = null
+    colabfold_alphafold2_params_link = null
 
     // Colabfold paths
-    colabfold_envdb_path              = null
-    colabfold_uniref30_path           = null
-    colabfold_alphafold2_params_path  = null // samplesheets with multimers must be >2021-07
+    colabfold_envdb_path             = null
+    colabfold_uniref30_path          = null
+    colabfold_alphafold2_params_path = null // samplesheets with multimers must be >2021-07
 
     // Esmfold parameters
     esmfold_db           = null
@@ -131,10 +131,10 @@ params {
     esm2_t36_3B_UR50D_contact_regression = null
 
     // Esmfold paths
-    esmfold_params_path                  = null
+    esmfold_params_path = null
 
     // RoseTTAFold_All_Atom parameters
-    rosettafold_all_atom_db             = null
+    rosettafold_all_atom_db = null
 
     // RoseTTAFold_All_Atom links
     rosettafold_all_atom_uniref30_link      = null
@@ -156,49 +156,49 @@ params {
     helixfold3_max_template_date = "2038-01-19"
 
     // Helixfold3 links
-    helixfold3_uniclust30_link          = null
-    helixfold3_ccd_preprocessed_link    = null
-    helixfold3_rfam_link                = null
-    helixfold3_init_models_link         = null
-    helixfold3_bfd_link                 = null
-    helixfold3_small_bfd_link           = null
-    helixfold3_uniprot_sprot_link       = null
-    helixfold3_uniprot_trembl_link      = null
-    helixfold3_pdb_seqres_link          = null
-    helixfold3_uniref90_link            = null
-    helixfold3_mgnify_link              = null
-    helixfold3_pdb_mmcif_link           = null
-    helixfold3_obsolete_link            = null
-    helixfold3_maxit_src_link           = null
+    helixfold3_uniclust30_link       = null
+    helixfold3_ccd_preprocessed_link = null
+    helixfold3_rfam_link             = null
+    helixfold3_init_models_link      = null
+    helixfold3_bfd_link              = null
+    helixfold3_small_bfd_link        = null
+    helixfold3_uniprot_sprot_link    = null
+    helixfold3_uniprot_trembl_link   = null
+    helixfold3_pdb_seqres_link       = null
+    helixfold3_uniref90_link         = null
+    helixfold3_mgnify_link           = null
+    helixfold3_pdb_mmcif_link        = null
+    helixfold3_obsolete_link         = null
+    helixfold3_maxit_src_link        = null
 
     // Helixfold3 paths
-    helixfold3_uniclust30_path          = null
-    helixfold3_ccd_preprocessed_path    = null
-    helixfold3_rfam_path                = null
-    helixfold3_init_models_path         = null
-    helixfold3_bfd_path                 = null
-    helixfold3_small_bfd_path           = null
-    helixfold3_uniprot_path             = null
-    helixfold3_pdb_seqres_path          = null
-    helixfold3_uniref90_path            = null
-    helixfold3_mgnify_path              = null
-    helixfold3_pdb_mmcif_path           = null
-    helixfold3_obsolete_path            = null
-    helixfold3_maxit_src_path           = null
+    helixfold3_uniclust30_path       = null
+    helixfold3_ccd_preprocessed_path = null
+    helixfold3_rfam_path             = null
+    helixfold3_init_models_path      = null
+    helixfold3_bfd_path              = null
+    helixfold3_small_bfd_path        = null
+    helixfold3_uniprot_path          = null
+    helixfold3_pdb_seqres_path       = null
+    helixfold3_uniref90_path         = null
+    helixfold3_mgnify_path           = null
+    helixfold3_pdb_mmcif_path        = null
+    helixfold3_obsolete_path         = null
+    helixfold3_maxit_src_path        = null
 
     // RosettaFold2NA parameters
-    rosettafold2na_db           = null
+    rosettafold2na_db = null
 
     // RosettaFold2NA links
-    rosettafold2na_uniref30_link = null
-    rosettafold2na_bfd_link      = null
-    rosettafold2na_pdb100_link   = null
-    rosettafold2na_weights_link  = null
-    rfam_full_region_link        = null
-    rfam_cm_link                 = null
+    rosettafold2na_uniref30_link     = null
+    rosettafold2na_bfd_link          = null
+    rosettafold2na_pdb100_link       = null
+    rosettafold2na_weights_link      = null
+    rfam_full_region_link            = null
+    rfam_cm_link                     = null
     rnacentral_rfam_annotations_link = null
-    rnacentral_id_mapping_link   = null
-    rnacentral_sequences_link    = null
+    rnacentral_id_mapping_link       = null
+    rnacentral_sequences_link        = null
 
     // RosettaFold2NA paths
     rosettafold2na_uniref30_path = null
@@ -208,16 +208,16 @@ params {
     rosettafold2na_rna_path      = null
 
     // Foldseek params
-    skip_foldseek               = true
-    foldseek_easysearch_arg     = null
+    skip_foldseek           = true
+    foldseek_easysearch_arg = null
 
     // Foldseek databases paths
     foldseek_db      = null
     foldseek_db_path = null
 
     // Process skipping options
-    skip_multiqc                = false
-    skip_visualisation          = false
+    skip_multiqc       = false
+    skip_visualisation = false
 
     // MultiQC options
     multiqc_config              = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -579,7 +579,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.6.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {

--- a/subworkflows/local/prepare_alphafold2_dbs.nf
+++ b/subworkflows/local/prepare_alphafold2_dbs.nf
@@ -21,7 +21,7 @@ workflow PREPARE_ALPHAFOLD2_DBS {
 
     take:
     alphafold2_db            // directory: path to alphafold2 DBs
-    alphafold2_full_dbs                 //   boolean: Use full databases (otherwise reduced version)
+    alphafold2_full_dbs      //   boolean: Use full databases (otherwise reduced version)
     bfd_path                 // directory: /path/to/bfd/
     small_bfd_path           // directory: /path/to/small_bfd/
     alphafold2_params_path   // directory: /path/to/alphafold2/params/
@@ -54,23 +54,23 @@ workflow PREPARE_ALPHAFOLD2_DBS {
 
     if (alphafold2_db) {
         if (alphafold2_full_dbs) {
-            ch_bfd       = channel.value(file(bfd_path, checkIfExists: true))
-            ch_small_bfd = channel.value(file("${projectDir}/assets/dummy_db"))
+            ch_bfd       = channel.value(files(bfd_path, checkIfExists: true))
+            ch_small_bfd = channel.value(files("${projectDir}/assets/dummy_db"))
         }
         else {
             ch_bfd       = channel.value(file("${projectDir}/assets/dummy_db"))
-            ch_small_bfd = channel.value(file(small_bfd_path, checkIfExists: true))
+            ch_small_bfd = channel.value(files(small_bfd_path, checkIfExists: true))
         }
 
-        ch_params         = channel.value(file(alphafold2_params_path, checkIfExists: true))
-        ch_mgnify         = channel.value(file(mgnify_path, checkIfExists: true))
-        ch_pdb70          = channel.value(file(pdb70_path, checkIfExists: true))
-        ch_mmcif_files    = channel.value(file(pdb_mmcif_path, checkIfExists: true))
-        ch_obsolete       = channel.value(file(pdb_obsolete_path, type: 'file', checkIfExists: true))
-        ch_uniref30       = channel.value(file(alphafold2_uniref30_path, type: 'any', checkIfExists: true))
-        ch_uniref90       = channel.value(file(uniref90_path, checkIfExists: true))
-        ch_pdb_seqres     = channel.value(file(pdb_seqres_path, checkIfExists: true))
-        ch_uniprot        = channel.value(file(uniprot_path, checkIfExists: true))
+        ch_params         = channel.value(files(alphafold2_params_path, checkIfExists: true))
+        ch_mgnify         = channel.value(files(mgnify_path, checkIfExists: true))
+        ch_pdb70          = channel.value(files(pdb70_path, checkIfExists: true))
+        ch_mmcif_files    = channel.value(files(pdb_mmcif_path, checkIfExists: true))
+        ch_obsolete       = channel.value(files(pdb_obsolete_path, type: 'file', checkIfExists: true))
+        ch_uniref30       = channel.value(files(alphafold2_uniref30_path, type: 'any', checkIfExists: true))
+        ch_uniref90       = channel.value(files(uniref90_path, checkIfExists: true))
+        ch_pdb_seqres     = channel.value(files(pdb_seqres_path, checkIfExists: true))
+        ch_uniprot        = channel.value(files(uniprot_path, checkIfExists: true))
     }
     else {
         if (alphafold2_full_dbs) {

--- a/subworkflows/local/prepare_alphafold3_dbs.nf
+++ b/subworkflows/local/prepare_alphafold3_dbs.nf
@@ -42,16 +42,16 @@ workflow PREPARE_ALPHAFOLD3_DBS {
     ch_versions   = channel.empty()
 
     if (alphafold3_db) {
-        ch_params         = channel.value(file(alphafold3_params_path, checkIfExists: true))
-        ch_small_bfd      = channel.value(file(small_bfd_path, checkIfExists: true))
-        ch_mgnify         = channel.value(file(mgnify_path, checkIfExists: true))
-        ch_mmcif          = channel.value(file(pdb_mmcif_path, checkIfExists: true))
-        ch_uniref90       = channel.value(file(uniref90_path, checkIfExists: true))
-        ch_pdb_seqres     = channel.value(file(pdb_seqres_path, checkIfExists: true))
-        ch_uniprot        = channel.value(file(uniprot_path, checkIfExists: true))
-        ch_rnacentral     = channel.value(file(rnacentral_active_seq_path))
-        ch_nt_rna         = channel.value(file(nt_rna_2023_02_23_path))
-        ch_rfam           = channel.value(file(rfam_path))
+        ch_params         = channel.value(files(alphafold3_params_path, checkIfExists: true))
+        ch_small_bfd      = channel.value(files(small_bfd_path, checkIfExists: true))
+        ch_mgnify         = channel.value(files(mgnify_path, checkIfExists: true))
+        ch_mmcif          = channel.value(files(pdb_mmcif_path, checkIfExists: true))
+        ch_uniref90       = channel.value(files(uniref90_path, checkIfExists: true))
+        ch_pdb_seqres     = channel.value(files(pdb_seqres_path, checkIfExists: true))
+        ch_uniprot        = channel.value(files(uniprot_path, checkIfExists: true))
+        ch_rnacentral     = channel.value(files(rnacentral_active_seq_path))
+        ch_nt_rna         = channel.value(files(nt_rna_2023_02_23_path))
+        ch_rfam           = channel.value(files(rfam_path))
     } else {
 
         ARIA2_SMALL_BFD (

--- a/subworkflows/local/prepare_boltz_dbs.nf
+++ b/subworkflows/local/prepare_boltz_dbs.nf
@@ -26,11 +26,11 @@ workflow PREPARE_BOLTZ_DBS {
     ch_versions     = channel.empty()
 
     if (boltz_db) {
-        ch_boltz_ccd    = channel.value(file(boltz_ccd, checkIfExists: true))
-        ch_boltz_model  = channel.value(file(boltz_model, checkIfExists: true))
-        ch_boltz2_aff   = channel.value(file(boltz2_aff, checkIfExists: true))
-        ch_boltz2_conf  = channel.value(file(boltz2_conf, checkIfExists: true))
-        ch_boltz2_mols  = channel.value(file(boltz2_mols, checkIfExists: true))
+        ch_boltz_ccd    = channel.value(files(boltz_ccd, checkIfExists: true))
+        ch_boltz_model  = channel.value(files(boltz_model, checkIfExists: true))
+        ch_boltz2_aff   = channel.value(files(boltz2_aff, checkIfExists: true))
+        ch_boltz2_conf  = channel.value(files(boltz2_conf, checkIfExists: true))
+        ch_boltz2_mols  = channel.value(files(boltz2_mols, checkIfExists: true))
     } else {
         ARIA2_BOLTZ_CCD(
             [

--- a/subworkflows/local/prepare_colabfold_dbs.nf
+++ b/subworkflows/local/prepare_colabfold_dbs.nf
@@ -68,14 +68,14 @@ workflow PREPARE_COLABFOLD_DBS {
                                     .out
                                     .db_indexed
                                     .map { _meta, dir ->
-                                        file("${dir}/*")
+                                        files("${dir}/*")
                                     }
                 ch_versions = ch_versions.mix(MMSEQS_CREATEINDEX_COLABFOLDDB.out.versions)
 
             } else {
                 ch_colabfold_db = ch_colabfold_db
                                     .map { dir_path ->
-                                        file("${dir_path}/*")
+                                        files("${dir_path}/*")
                                     }
             }
 
@@ -98,14 +98,14 @@ workflow PREPARE_COLABFOLD_DBS {
                                 .out
                                 .db_indexed
                                 .map { _meta, dir ->
-                                    file("${dir}/*")
+                                    files("${dir}/*")
                                 }
                 ch_versions = ch_versions.mix(MMSEQS_CREATEINDEX_UNIPROT30.out.versions)
 
             } else {
                 ch_uniref30 = ch_uniref30
                                 .map { dir_path ->
-                                    file("${dir_path}/*")
+                                    files("${dir_path}/*")
                                 }
             }
         }

--- a/subworkflows/local/prepare_colabfold_dbs.nf
+++ b/subworkflows/local/prepare_colabfold_dbs.nf
@@ -28,10 +28,10 @@ workflow PREPARE_COLABFOLD_DBS {
     ch_versions     = channel.empty()
 
     if (colabfold_db) {
-        ch_params = channel.value(file(colabfold_alphafold2_params_path,  type: 'any', checkIfExists: true))
+        ch_params = channel.value(files(colabfold_alphafold2_params_path,  type: 'any', checkIfExists: true))
         if (!use_msa_server) {
-            ch_colabfold_db = channel.value(file(colabfold_envdb_path, type: 'any', checkIfExists: true))
-            ch_uniref30     = channel.value(file(colabfold_uniref30_path, type: 'any', checkIfExists: true))
+            ch_colabfold_db = channel.value(files(colabfold_envdb_path, type: 'any', checkIfExists: true))
+            ch_uniref30     = channel.value(files(colabfold_uniref30_path, type: 'any', checkIfExists: true))
         }
     }
     else {

--- a/subworkflows/local/prepare_esmfold_dbs.nf
+++ b/subworkflows/local/prepare_esmfold_dbs.nf
@@ -19,7 +19,7 @@ workflow PREPARE_ESMFOLD_DBS {
     ch_versions   = channel.empty()
 
     if (esmfold_db) {
-        ch_params     = channel.value(file(esmfold_params_path, checkIfExists: true ))
+        ch_params     = channel.value(files(esmfold_params_path, checkIfExists: true ))
     }
     else {
         ARIA2_ESMFOLD_3B_V1 (

--- a/subworkflows/local/prepare_rosettafold2na_dbs.nf
+++ b/subworkflows/local/prepare_rosettafold2na_dbs.nf
@@ -33,11 +33,11 @@ workflow PREPARE_ROSETTAFOLD2NA_DBS {
     ch_versions = channel.empty()
 
     if (rosettafold2na_db) {
-        ch_bfd      = channel.value(file(rosettafold2na_bfd_path, checkIfExists: true))
-        ch_uniref30 = channel.value(file(rosettafold2na_uniref30_path, checkIfExists: true))
-        ch_pdb100   = channel.value(file(rosettafold2na_pdb100_path, checkIfExists: true))
-        ch_weights  = channel.value(file(rosettafold2na_weights_path, checkIfExists: true))
-        ch_rna      = channel.value(file(rosettafold2na_rna_path, checkIfExists: true))
+        ch_bfd      = channel.value(files(rosettafold2na_bfd_path, checkIfExists: true))
+        ch_uniref30 = channel.value(files(rosettafold2na_uniref30_path, checkIfExists: true))
+        ch_pdb100   = channel.value(files(rosettafold2na_pdb100_path, checkIfExists: true))
+        ch_weights  = channel.value(files(rosettafold2na_weights_path, checkIfExists: true))
+        ch_rna      = channel.value(files(rosettafold2na_rna_path, checkIfExists: true))
     } else {
         ARIA2_BFD(rosettafold2na_bfd_link)
         ch_bfd = ARIA2_BFD

--- a/subworkflows/local/prepare_rosettafold_all_atom_dbs.nf
+++ b/subworkflows/local/prepare_rosettafold_all_atom_dbs.nf
@@ -27,10 +27,10 @@ workflow PREPARE_ROSETTAFOLD_ALL_ATOM_DBS {
     ch_versions                 = channel.empty()
 
     if (rosettafold_all_atom_db) {
-        ch_bfd                  = channel.value(file(rosettafold_all_atom_bfd_path, checkIfExists: true))
-        ch_uniref30             = channel.value(file(rosettafold_all_atom_uniref30_path, checkIfExists: true))
-        ch_pdb100               = channel.value(file(rosettafold_all_atom_pdb100_path, checkIfExists: true))
-        ch_rfaa_paper_weights   = channel.value(file(rosettafold_all_atom_paper_weights_path, checkIfExists: true))
+        ch_bfd                  = channel.value(files(rosettafold_all_atom_bfd_path, checkIfExists: true))
+        ch_uniref30             = channel.value(files(rosettafold_all_atom_uniref30_path, checkIfExists: true))
+        ch_pdb100               = channel.value(files(rosettafold_all_atom_pdb100_path, checkIfExists: true))
+        ch_rfaa_paper_weights   = channel.value(files(rosettafold_all_atom_paper_weights_path, checkIfExists: true))
     }
     else {
         ARIA2_BFD(rosettafold_all_atom_bfd_link)

--- a/workflows/boltz.nf
+++ b/workflows/boltz.nf
@@ -22,13 +22,6 @@ include { BOLTZ_FASTA } from '../modules/local/boltz_fasta'
 include { SPLIT_MSA } from '../modules/local/split_msa'
 include { MMSEQS_COLABFOLDSEARCH } from '../modules/local/mmseqs_colabfoldsearch'
 include { MULTIFASTA_TO_CSV      } from '../modules/local/multifasta_to_csv'
-//
-// SUBWORKFLOW: Consisting entirely of nf-core/modules
-//
-include { paramsSummaryMap       } from 'plugin/nf-schema'
-include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_proteinfold_pipeline'
 
 //
 // MODULE: Boltz


### PR DESCRIPTION
## Summary

* Replace file() with files() for glob patterns  in `prepare_*.nf` subworkflows to avoid deprecation warnings introduced in Nextflow `26.04.1` (`WARN: The file() function was called with a glob pattern that matched a collection of files -- use files() instead`).
* Update nf-schema to version `2.7.2`, fixes some issues introduced by the type casting in the last release (e.g. see [comment](https://github.com/nf-core/proteinfold/pull/607#issuecomment-4448500175)) 
* Remove non-existent `docker.pullStrategy` config option.
* Remove unused include statements in `boltz` workflow.
* Some formatting issues.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
