### PR TITLE
Update fix_obsolete.py to avoid infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#602](https://github.com/nf-core/proteinfold/issues/602)] - Fix file name collision when staging ColabFold databases to the same directory in `MMSEQS_COLABFOLDSEARCH`.
 - [[#603](https://github.com/nf-core/proteinfold/issues/603)] - Allow AlphaFold3 JSON files as direct samplesheet input, bypassing `FASTA_TO_ALPHAFOLD3_JSON`.
 - [[#607](https://github.com/nf-core/proteinfold/pull/607)] - Fix Nextflow 26.04.1 warnings when using glob patterns in `file()` and other small fixes.
+- [[#620](https://github.com/nf-core/proteinfold/pull/620)] - Update `fix_obsolete.py` to avoid infinite loop.
 
 | Old parameter              | New parameter   |
 | -------------------------- | --------------- |

--- a/bin/fix_obsolete.py
+++ b/bin/fix_obsolete.py
@@ -22,8 +22,13 @@ with open(argv[1]) as f:
             continue
         map_out = ss[3]
         if ss[2] in removed: continue
+        seen = set()
         while True:
             if map_out not in mapping: break
+            if map_out in seen:
+                # cycle detected; stop following the chain to avoid infinite loop
+                break
+            seen.add(map_out)
             removed.add(map_out)
             map_out = mapping[map_out]
         print(f"{ss[0]}    {ss[1]} {ss[2]}     {map_out}")

--- a/bin/fix_obsolete.py
+++ b/bin/fix_obsolete.py
@@ -26,7 +26,8 @@ with open(argv[1]) as f:
         while True:
             if map_out not in mapping: break
             if map_out in seen:
-                # cycle detected; stop following the chain to avoid infinite loop
+                # cycle detected; treat as removed (no successor) to avoid infinite loop
+                map_out = ''
                 break
             seen.add(map_out)
             removed.add(map_out)


### PR DESCRIPTION
Updated fix_obsolete.py to handle recursive mappings in obsolete.dat to avoid infinite loop. Latest version of obsolete.dat recursively maps 8UJJ to 8UJJ.

<!--
# nf-core/proteinfold pull request

Many thanks for contributing to nf-core/proteinfold!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.