### PR TITLE
Improvement to nf-tests for 2.1.0

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test-changes
       - runner=4cpu-linux-x64
-      - volume=80gb
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test-changes
       - runner=4cpu-linux-x64
+      - volume=80gb
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
@@ -51,7 +52,7 @@ jobs:
           NFT_VER: ${{ env.NFT_VER }}
           SKIP_SCIENTIFIC: "true"
         with:
-          max_shards: 7
+          max_shards: 15
 
       - name: debug
         run: |
@@ -65,6 +66,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test
       - runner=4cpu-linux-x64
+      - volume=80gb
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #633](https://github.com/nf-core/proteinfold/pull/633)] - Fix comparison reports with esmfold for multirow samplesheets.
 - [[PR #634](https://github.com/nf-core/proteinfold/pull/634)] - Add support for outputs in cif format.
 - [[PR #636](https://github.com/nf-core/proteinfold/pull/636)] - Resolve alphafold2 `ext.args` in closure.
+- [[#365](https://github.com/nf-core/proteinfold/issues/365)] - Run nf-tests with module containers so captured versions match.
 
 | Old parameter              | New parameter   |
 | -------------------------- | --------------- |

--- a/conf/test.config
+++ b/conf/test.config
@@ -31,9 +31,3 @@ params {
     input           = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
     alphafold2_db   = "${projectDir}/assets/dummy_db_dir"
 }
-
-process {
-    withName: 'RUN_ALPHAFOLD2' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_alphafold3_download.config
+++ b/conf/test_alphafold3_download.config
@@ -30,9 +30,3 @@ params {
     input                  = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
     alphafold3_params_path = "${projectDir}/assets/dummy_db_dir"
 }
-
-process {
-    withName: 'ARIA2|UNTAR|DOWNLOAD_PDBMMCIF_AF3|RUN_ALPHAFOLD3' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_alphafold3_standard.config
+++ b/conf/test_alphafold3_standard.config
@@ -30,9 +30,3 @@ params {
     input           = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
     alphafold3_db   = "${projectDir}/assets/dummy_db_dir"
 }
-
-process {
-    withName: 'RUN_ALPHAFOLD3_INFERENCE|RUN_ALPHAFOLD3_DATAPIPELINE' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_alphafold_download.config
+++ b/conf/test_alphafold_download.config
@@ -30,9 +30,3 @@ params {
     alphafold2_mode = 'standard'
     input           = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
 }
-
-process {
-    withName: 'ARIA2|UNTAR|RUN_ALPHAFOLD2' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_alphafold_split.config
+++ b/conf/test_alphafold_split.config
@@ -31,9 +31,3 @@ params {
     input           = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
     alphafold2_db   = "${projectDir}/assets/dummy_db_dir"
 }
-
-process {
-    withName: 'RUN_ALPHAFOLD2_MSA|RUN_ALPHAFOLD2_PRED' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_boltz.config
+++ b/conf/test_boltz.config
@@ -30,9 +30,3 @@ params {
     colabfold_db            = "${projectDir}/assets/dummy_db_dir"
     boltz_db                = "${projectDir}/assets/dummy_db_dir"
 }
-
-process {
-    withName: 'MMSEQS_COLABFOLDSEARCH|RUN_BOLTZ' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_colabfold_download.config
+++ b/conf/test_colabfold_download.config
@@ -30,9 +30,3 @@ params {
     use_msa_server   = true
     input            = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
 }
-
-process {
-    withName: 'ARIA2|UNTAR|COLABFOLD_BATCH' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_colabfold_local.config
+++ b/conf/test_colabfold_local.config
@@ -28,9 +28,3 @@ params {
     colabfold_db     = "${projectDir}/assets/dummy_db_dir"
     input            = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
 }
-
-process {
-    withName: 'MMSEQS_COLABFOLDSEARCH|COLABFOLD_BATCH' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_colabfold_webserver.config
+++ b/conf/test_colabfold_webserver.config
@@ -29,9 +29,3 @@ params {
     colabfold_db     = "${projectDir}/assets/dummy_db_dir"
     input            = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
 }
-
-process {
-    withName: 'COLABFOLD_BATCH' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_esmfold.config
+++ b/conf/test_esmfold.config
@@ -28,9 +28,3 @@ params {
     esmfold_db       = "${projectDir}/assets/dummy_db_dir"
     input            = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
 }
-
-process {
-    withName: 'RUN_ESMFOLD' {
-        container = 'quay.io/biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_helixfold3.config
+++ b/conf/test_helixfold3.config
@@ -28,9 +28,3 @@ params {
     helixfold3_db = "${projectDir}/assets/dummy_db_dir"
     input         = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
 }
-
-process {
-    withName: 'RUN_HELIXFOLD3' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_rosettafold2na.config
+++ b/conf/test_rosettafold2na.config
@@ -28,9 +28,3 @@ params {
     rosettafold2na_db    = "${projectDir}/assets/dummy_db_dir"
     input                = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/rna_complex_samplesheet.csv'
 }
-
-process {
-    withName: 'RUN_ROSETTAFOLD2NA' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_rosettafold_all_atom.config
+++ b/conf/test_rosettafold_all_atom.config
@@ -28,9 +28,3 @@ params {
     rosettafold_all_atom_db = "${projectDir}/assets/dummy_db_dir"
     input                   = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet.csv'
 }
-
-process {
-    withName: 'RUN_ROSETTAFOLD_ALL_ATOM' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/conf/test_split_fasta.config
+++ b/conf/test_split_fasta.config
@@ -29,9 +29,3 @@ params {
     colabfold_db     = "${projectDir}/assets/dummy_db_dir"
     input            = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v2.0/samplesheet_multimer.csv'
 }
-
-process {
-    withName: 'MMSEQS_COLABFOLDSEARCH|COLABFOLD_BATCH' {
-        container = 'biocontainers/gawk:5.1.0'
-    }
-}

--- a/modules/local/compare_structures/main.nf
+++ b/modules/local/compare_structures/main.nf
@@ -41,7 +41,7 @@ process COMPARE_STRUCTURES {
 
     stub:
     """
-    touch test_alphafold2_report.html
+    touch ${meta.id}_comparison_report.html
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/generate_report/main.nf
+++ b/modules/local/generate_report/main.nf
@@ -47,9 +47,9 @@ process GENERATE_REPORT {
 
     stub:
     """
-    touch test_alphafold2_report.html
-    touch test_seq_coverage.png
-    touch test_LDDT.html
+    touch ${meta.id}_${meta.model}_report.html
+    touch ${meta.id}_${meta.model}_seq_coverage.png
+    touch ${meta.id}_coverage_LDDT.html
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/tests/alphafold2_download.nf.test.snap
+++ b/tests/alphafold2_download.nf.test.snap
@@ -4,10 +4,10 @@
             25,
             {
                 "ARIA2": {
-                    "aria2": null
+                    "aria2": "1.36.0"
                 },
                 "ARIA2_PDB_SEQRES": {
-                    "aria2": null
+                    "aria2": "1.36.0"
                 },
                 "COMBINE_UNIPROT": {
                     "sed": 4.7
@@ -21,12 +21,12 @@
                     "generate_report.py": "Python 3.12.7"
                 },
                 "RUN_ALPHAFOLD2": {
-                    "python": "unknown",
+                    "python": "3.11.14",
                     "alphafold2": "unknown",
-                    "jax": "unknown",
-                    "jaxlib": "unknown",
-                    "numpy": "unknown",
-                    "biopython": "unknown"
+                    "jax": "0.4.26",
+                    "jaxlib": "0.4.26",
+                    "numpy": "1.24.3",
+                    "biopython": 1.79
                 },
                 "Workflow": {
                     "nf-core/proteinfold": "v2.1.0dev"
@@ -88,7 +88,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_alphafold2_report.html",
+                "reports/T1026_alphafold2_report.html"
             ],
             [
                 "mgy_clusters.fa:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -131,10 +132,11 @@
                 "T1026.pdb:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T11:58:00.077126331",
+        "timestamp": "2026-05-29T12:01:54.780944659",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/alphafold2_split.nf.test.snap
+++ b/tests/alphafold2_split.nf.test.snap
@@ -8,18 +8,18 @@
                     "generate_report.py": "Python 3.12.7"
                 },
                 "RUN_ALPHAFOLD2_MSA": {
-                    "python": null,
+                    "python": "3.11.14",
                     "alphafold2": "unknown",
-                    "numpy": "unknown",
-                    "biopython": "unknown"
+                    "numpy": "1.24.3",
+                    "biopython": 1.79
                 },
                 "RUN_ALPHAFOLD2_PRED": {
-                    "python": null,
+                    "python": "3.11.14",
                     "alphafold2": "unknown",
-                    "jax": "unknown",
-                    "jaxlib": "unknown",
-                    "numpy": "unknown",
-                    "biopython": "unknown"
+                    "jax": "0.4.26",
+                    "jaxlib": "0.4.26",
+                    "numpy": "1.24.3",
+                    "biopython": 1.79
                 },
                 "Workflow": {
                     "nf-core/proteinfold": "v2.1.0dev"
@@ -64,7 +64,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_alphafold2_report.html",
+                "reports/T1026_alphafold2_report.html"
             ],
             [
                 "T1024_alphafold2_msa.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -89,10 +90,11 @@
                 "T1026.pdb:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T11:58:14.638567413",
+        "timestamp": "2026-05-29T12:02:08.331526798",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/alphafold3.nf.test.snap
+++ b/tests/alphafold3.nf.test.snap
@@ -11,18 +11,18 @@
                     "generate_report.py": "Python 3.12.7"
                 },
                 "RUN_ALPHAFOLD3_DATAPIPELINE": {
-                    "python": "unknown",
+                    "python": "3.11.12",
                     "alphafold3": "unknown",
-                    "hmmer": "unknown"
+                    "hmmer": 3.4
                 },
                 "RUN_ALPHAFOLD3_INFERENCE": {
-                    "python": "unknown",
+                    "python": "3.11.12",
                     "alphafold3": "unknown",
-                    "jax": "unknown",
-                    "jaxlib": "unknown",
-                    "numpy": "unknown",
-                    "biopython": "unknown",
-                    "rdkit": "unknown"
+                    "jax": "0.4.34",
+                    "jaxlib": "0.4.34",
+                    "numpy": "2.1.3",
+                    "biopython": 1.85,
+                    "rdkit": "2024.03.5"
                 },
                 "Workflow": {
                     "nf-core/proteinfold": "v2.1.0dev"
@@ -67,7 +67,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_alphafold3_report.html",
+                "reports/T1026_alphafold3_report.html"
             ],
             [
                 "T1024_alphafold3_msa.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -94,10 +95,11 @@
                 "T1026.json:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_alphafold3_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_alphafold3_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T11:58:30.358487564",
+        "timestamp": "2026-05-29T12:02:22.195461228",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/boltz.nf.test.snap
+++ b/tests/boltz.nf.test.snap
@@ -14,11 +14,11 @@
                     "generate_report.py": "Python 3.12.7"
                 },
                 "MMSEQS_COLABFOLDSEARCH": {
-                    "colabfold_search": "unknown",
-                    "mmseqs": null
+                    "colabfold_search": "1.6.1",
+                    "mmseqs": "74c9370d45ba10446fe049c3603bf5f877817e95"
                 },
                 "RUN_BOLTZ": {
-                    "boltz": "unknown"
+                    "boltz": "2.2.1"
                 },
                 "SPLIT_MSA": {
                     "python": "3.14.0"
@@ -73,7 +73,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html",
+                "reports/T1024_boltz_report.html",
+                "reports/T1026_boltz_report.html",
                 "split",
                 "split/output_msa",
                 "split/output_msa/A.csv",
@@ -112,14 +113,15 @@
                 "T1026.json:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1024_boltz_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_boltz_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "A.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "B.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "T1024.yaml:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "T1026.yaml:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T11:58:46.633453978",
+        "timestamp": "2026-05-29T12:02:37.248096039",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/colabfold_download.nf.test.snap
+++ b/tests/colabfold_download.nf.test.snap
@@ -4,11 +4,11 @@
             9,
             {
                 "ARIA2": {
-                    "aria2": null
+                    "aria2": "1.36.0"
                 },
                 "COLABFOLD_BATCH": {
-                    "alphafold_colabfold": "unknown",
-                    "colabfold_batch": "unknown"
+                    "alphafold_colabfold": "2.3.10",
+                    "colabfold_batch": "1.5.5"
                 },
                 "GENERATE_REPORT": {
                     "python": "3.12.7",
@@ -69,7 +69,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_colabfold_report.html",
+                "reports/T1026_colabfold_report.html"
             ],
             [
                 [
@@ -104,10 +105,11 @@
                 "input.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_colabfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_colabfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T15:01:54.756116028",
+        "timestamp": "2026-05-29T12:20:51.734751623",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/colabfold_local.nf.test.snap
+++ b/tests/colabfold_local.nf.test.snap
@@ -4,16 +4,16 @@
             9,
             {
                 "COLABFOLD_BATCH": {
-                    "alphafold_colabfold": "unknown",
-                    "colabfold_batch": "unknown"
+                    "alphafold_colabfold": "2.3.10",
+                    "colabfold_batch": "1.5.5"
                 },
                 "GENERATE_REPORT": {
                     "python": "3.12.7",
                     "generate_report.py": "Python 3.12.7"
                 },
                 "MMSEQS_COLABFOLDSEARCH": {
-                    "colabfold_search": "unknown",
-                    "mmseqs": null
+                    "colabfold_search": "1.6.1",
+                    "mmseqs": "74c9370d45ba10446fe049c3603bf5f877817e95"
                 },
                 "MULTIFASTA_TO_CSV": {
                     "sed": 4.7
@@ -66,7 +66,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_colabfold_report.html",
+                "reports/T1026_colabfold_report.html"
             ],
             [
                 "T1024_chainwise_ipsae.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -98,10 +99,11 @@
                 "input.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_colabfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_colabfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T15:02:09.999749672",
+        "timestamp": "2026-05-29T12:03:02.971630953",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/colabfold_webserver.nf.test.snap
+++ b/tests/colabfold_webserver.nf.test.snap
@@ -4,8 +4,8 @@
             7,
             {
                 "COLABFOLD_BATCH": {
-                    "alphafold_colabfold": "unknown",
-                    "colabfold_batch": "unknown"
+                    "alphafold_colabfold": "2.3.10",
+                    "colabfold_batch": "1.5.5"
                 },
                 "GENERATE_REPORT": {
                     "python": "3.12.7",
@@ -62,7 +62,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_colabfold_report.html",
+                "reports/T1026_colabfold_report.html"
             ],
             [
                 "T1024_chainwise_ipsae.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -94,10 +95,11 @@
                 "input.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_colabfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_colabfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T15:02:24.412363191",
+        "timestamp": "2026-05-29T12:03:19.488094161",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -7,12 +7,12 @@
                     "generate_report.py": "Python 3.12.7"
                 },
                 "RUN_ALPHAFOLD2": {
-                    "python": "unknown",
+                    "python": "3.11.14",
                     "alphafold2": "unknown",
-                    "jax": "unknown",
-                    "jaxlib": "unknown",
-                    "numpy": "unknown",
-                    "biopython": "unknown"
+                    "jax": "0.4.26",
+                    "jaxlib": "0.4.26",
+                    "numpy": "1.24.3",
+                    "biopython": 1.79
                 },
                 "Workflow": {
                     "nf-core/proteinfold": "v2.1.0dev"
@@ -53,7 +53,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_alphafold2_report.html",
+                "reports/T1026_alphafold2_report.html"
             ],
             [
                 "T1024_alphafold2_msa.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -76,10 +77,11 @@
                 "T1026.pdb:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T11:59:44.891085767",
+        "timestamp": "2026-05-29T12:03:38.054994856",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/esmfold.nf.test.snap
+++ b/tests/esmfold.nf.test.snap
@@ -9,11 +9,11 @@
                 },
                 "RUN_ESMFOLD": {
                     "esm-fold": "1.0.3",
-                    "python": "unknown",
-                    "pytorch": "unknown",
-                    "openfold": "unknown",
-                    "numpy": "unknown",
-                    "biopython": "unknown"
+                    "python": "3.9.23",
+                    "pytorch": "2.0.0+cu118",
+                    "openfold": "1.0.0",
+                    "numpy": "1.23.5",
+                    "biopython": 1.85
                 },
                 "Workflow": {
                     "nf-core/proteinfold": "v2.1.0dev"
@@ -37,7 +37,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_esmfold_report.html",
+                "reports/T1026_esmfold_report.html"
             ],
             [
                 "T1024_plddt.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -46,10 +47,11 @@
                 "T1026.pdb:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_esmfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_esmfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T11:59:58.125532552",
+        "timestamp": "2026-05-29T12:03:57.101911854",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/helixfold3.nf.test.snap
+++ b/tests/helixfold3.nf.test.snap
@@ -8,7 +8,7 @@
                     "generate_report.py": "Python 3.12.7"
                 },
                 "RUN_HELIXFOLD3": {
-                    "python": "unknown"
+                    "python": "3.9.23"
                 },
                 "Workflow": {
                     "nf-core/proteinfold": "v2.1.0dev"
@@ -61,7 +61,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/T1024_helixfold3_report.html",
+                "reports/T1026_helixfold3_report.html"
             ],
             [
                 "T1024.json:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -96,10 +97,11 @@
                 "T1026.pdb:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "T1024_helixfold3_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_helixfold3_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T12:00:12.95097286",
+        "timestamp": "2026-05-29T12:04:15.441305184",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/rosettafold2na.nf.test.snap
+++ b/tests/rosettafold2na.nf.test.snap
@@ -11,7 +11,7 @@
                     "python": "$(python3 --version 2>/dev/null | sed 's/Python //g' || echo \"unknown\")"
                 },
                 "RUN_ROSETTAFOLD2NA": {
-                    "python": "unknown",
+                    "python": "3.12.11",
                     "rosettafold2na": "v0.2"
                 },
                 "Workflow": {
@@ -28,7 +28,7 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html",
+                "reports/rna_complex_rosettafold2na_report.html",
                 "rosettafold2na",
                 "rosettafold2na/rf2na_input",
                 "rosettafold2na/rf2na_input/chain_map.tsv",
@@ -43,7 +43,7 @@
             [
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "rna_complex_rosettafold2na_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "chain_map.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "rna_complex_0_pae.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "rna_complex_plddt.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -51,7 +51,7 @@
                 "rna_complex.pdb:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T12:00:28.18549971",
+        "timestamp": "2026-05-29T12:04:34.383277932",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/rosettafold_all_atom.nf.test.snap
+++ b/tests/rosettafold_all_atom.nf.test.snap
@@ -8,7 +8,7 @@
                     "generate_report.py": "Python 3.12.7"
                 },
                 "RUN_ROSETTAFOLD_ALL_ATOM": {
-                    "python": "unknown",
+                    "python": "3.12.8",
                     "rosettafold-all-atom": "unknown"
                 },
                 "Workflow": {
@@ -31,7 +31,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html",
+                "reports/T1024_rosettafold_all_atom_report.html",
+                "reports/T1026_rosettafold_all_atom_report.html",
                 "rosettafold_all_atom",
                 "rosettafold_all_atom/T1024",
                 "rosettafold_all_atom/T1024/T1024_plddt.tsv",
@@ -54,7 +55,8 @@
                 "B.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1024_rosettafold_all_atom_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "T1026_rosettafold_all_atom_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "T1024_plddt.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "T1024_rosettafold_all_atom_msa.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "T1024_0_pae.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -65,7 +67,7 @@
                 "T1026.pdb:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T12:00:44.038745396",
+        "timestamp": "2026-05-29T12:04:52.527802748",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/split_fasta.nf.test.snap
+++ b/tests/split_fasta.nf.test.snap
@@ -4,16 +4,16 @@
             9,
             {
                 "COLABFOLD_BATCH": {
-                    "alphafold_colabfold": "unknown",
-                    "colabfold_batch": "unknown"
+                    "alphafold_colabfold": "2.3.10",
+                    "colabfold_batch": "1.5.5"
                 },
                 "GENERATE_REPORT": {
                     "python": "3.12.7",
                     "generate_report.py": "Python 3.12.7"
                 },
                 "MMSEQS_COLABFOLDSEARCH": {
-                    "colabfold_search": "unknown",
-                    "mmseqs": null
+                    "colabfold_search": "1.6.1",
+                    "mmseqs": "74c9370d45ba10446fe049c3603bf5f877817e95"
                 },
                 "MULTIFASTA_TO_CSV": {
                     "sed": 4.7
@@ -66,7 +66,8 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinfold_software_mqc_versions.yml",
                 "reports",
-                "reports/test_alphafold2_report.html"
+                "reports/H1065_H1065_N4-Cytosine_Methyltransferase_Serratia_marcescens_subunit_1_127_residues_colabfold_report.html",
+                "reports/H1065_H1065_N4-Cytosine_Methyltransferase_Serratia_marcescens_subunit_2_98_residues_colabfold_report.html"
             ],
             [
                 "H1065_H1065_N4-Cytosine_Methyltransferase_Serratia_marcescens_subunit_1_127_residues_chainwise_ipsae.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -98,10 +99,11 @@
                 "input.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "test_alphafold2_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "H1065_H1065_N4-Cytosine_Methyltransferase_Serratia_marcescens_subunit_1_127_residues_colabfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "H1065_H1065_N4-Cytosine_Methyltransferase_Serratia_marcescens_subunit_2_98_residues_colabfold_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-05-29T15:03:57.105744253",
+        "timestamp": "2026-05-29T12:22:58.536548024",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"


### PR DESCRIPTION
Resolves #365

- Stub runs now use real module containers, snapshots receive true version info
- Fixed stub run report filenames using `meta.id` and `meta.model` (solves filename clash failure)
- GitHub actions now shard more efficiently and request suitable volume size for pulling containers

<!--
# nf-core/proteinfold pull request

Many thanks for contributing to nf-core/proteinfold!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfold/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.