### PR TITLE
fix comparison reports with esmfold for multirow samplesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#456](https://github.com/nf-core/proteinfold/issues/456)] - Derive ranked metric ordering from structure filenames when generating TSV outputs.
 - [[#489](https://github.com/nf-core/proteinfold/issues/489)] - Specified Boltz output paths on `boltz_results_<sample_id>/`.
 - [[#576](https://github.com/nf-core/proteinfold/issues/576)] - Preserve native metric rank numbering and sort rank-derived outputs numerically.
+- [[ PR #633](https://github.com/nf-core/proteinfold/pull/633)] - Fix comparison reports with esmfold for multirow samplesheets.
 
 | Old parameter              | New parameter   |
 | -------------------------- | --------------- |

--- a/subworkflows/local/post_processing.nf
+++ b/subworkflows/local/post_processing.nf
@@ -49,16 +49,15 @@ workflow POST_PROCESSING {
         ch_versions = ch_versions.mix(GENERATE_REPORT.out.versions)
 
         if (requested_modes_size > 1){
-            ch_dummy_file = channel.fromPath("$projectDir/assets/NO_FILE")
+            def dummy_file = file("$projectDir/assets/NO_FILE", checkIfExists: true)
 
             def esm = ch_top_ranked_model.filter { it ->it[0].model == 'esmfold' }
             def not_esm = ch_top_ranked_model.filter { it -> it[0].model != 'esmfold' }
 
             esm = esm
-                    .map { it ->
-                        [it[0], it[1]]
+                    .map { meta, pdb ->
+                        [meta, pdb, dummy_file]
                     }
-                    .merge(ch_dummy_file)
 
             not_esm = not_esm
                         .map { it ->  [it[0], it[1]] }


### PR DESCRIPTION
Comparison report includes an MSA coverage plot for each mode. Since ESMFold does not use an MSA, it is populated with a dummy file. However by using merge, only the first of a multi-sample samplesheet gets populated with a dummy file and only a single comparison report can get generated. This change ensures that every sample gets the dummy msa file and generates a comparison report for every sample.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] `CHANGELOG.md` is updated.
