### PR TITLE
Fix missing X character in AF3 and Boltz fasta processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #641](https://github.com/nf-core/proteinfold/pull/641)] - Stabilise GPU nf-test snapshots and set a deterministic test random seed.
 - [[PR #644](https://github.com/nf-core/proteinfold/pull/644)] - Update pipeline template to [nf-core/tools 4.0.3](https://github.com/nf-core/tools/releases/tag/4.0.3).
 - [[PR #645](https://github.com/nf-core/proteinfold/pull/645)] - Update image version for alphafold3 modules and `colabfold_batch`.
+- [[PR #647](https://github.com/nf-core/proteinfold/pull/647)] - Fix missing X character in AF3 and Boltz fasta processing.
 
 | Old parameter              | New parameter   |
 | -------------------------- | --------------- |

--- a/bin/fasta_to_alphafold3_json.py
+++ b/bin/fasta_to_alphafold3_json.py
@@ -73,7 +73,7 @@ def infer_entity_type(header, sequence):
     if len(seq_set - set("ACTGN")) == 0:
         return "dna"
     # Protein: only 20 AA, not just A,C,T,G,U,N
-    protein_letters = set("ACDEFGHIKLMNPQRSTVWY")
+    protein_letters = set("ACDEFGHIKLMNPQRSTVWYX")
     if len(seq_set - protein_letters) == 0 and not (seq_set <= set("ACUGTN")):
         return "protein"
     # SMILES: fallback

--- a/bin/fasta_to_boltz.py
+++ b/bin/fasta_to_boltz.py
@@ -65,7 +65,7 @@ def infer_entity_type(header, sequence):
     if len(seq_set - set("ACTGN")) == 0:
         return "dna"
     # Protein: only 20 AA, not just A,C,T,G,U,N
-    protein_letters = set("ACDEFGHIKLMNPQRSTVWY")
+    protein_letters = set("ACDEFGHIKLMNPQRSTVWYX")
     if len(seq_set - protein_letters) == 0 and not (seq_set <= set("ACUGTN")):
         return "protein"
     # SMILES: fallback


### PR DESCRIPTION
Very quick fix to stop the scripts converting fasta inputs with `X` entries being categorised as smiles.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] `CHANGELOG.md` is updated.